### PR TITLE
Support provider context

### DIFF
--- a/ec2/constants.py
+++ b/ec2/constants.py
@@ -49,4 +49,4 @@ SECURITY_GROUP_REQUIRED_PROPERTIES = ['description', 'rules']
 KEYPAIR_REQUIRED_PROPERTIES = ['private_key_path']
 
 # Config
-AWS_CONFIG_PATH = '~/.aws_config'
+AWS_CONFIG_PATH = '~/.aws_config.json'

--- a/ec2/instance.py
+++ b/ec2/instance.py
@@ -427,7 +427,8 @@ def _get_instance_parameters():
             constants.INSTANCE_SECURITY_GROUP_RELATIONSHIP,
             ctx.instance)
 
-    if 'agents_security_group' in provider_variables:
+    if 'agents_security_group' in provider_variables and \
+            provider_variables['agents_security_group'] is not None:
         attached_group_ids.append(
             provider_variables['agents_security_group'])
 
@@ -452,7 +453,8 @@ def _get_instance_keypair(provider_variables):
         utils.get_target_external_resource_ids(
             constants.INSTANCE_KEYPAIR_RELATIONSHIP, ctx.instance)
 
-    if not list_of_keypairs and 'agents_keypair' in provider_variables:
+    if not list_of_keypairs and 'agents_keypair' in provider_variables \
+            and provider_variables['agents_keypair'] is not None:
         list_of_keypairs.append(provider_variables['agents_keypair'])
     elif len(list_of_keypairs) > 1:
         raise NonRecoverableError(

--- a/ec2/keypair.py
+++ b/ec2/keypair.py
@@ -38,14 +38,14 @@ def creation_validation(**_):
 
     key_file = _get_path_to_key_file()
     key_file_in_filesystem = _search_for_key_file(key_file)
-    key_pair_in_account = _get_key_pair_by_id(
-        ctx.node.properties['resource_id'])
 
     if ctx.node.properties['use_external_resource']:
         if not key_file_in_filesystem:
             raise NonRecoverableError(
                 'External resource, but the key file does not exist locally.')
-        if not key_pair_in_account:
+        try:
+            _get_key_pair_by_id(ctx.node.properties['resource_id'])
+        except NonRecoverableError:
             raise NonRecoverableError(
                 'External resource, '
                 'but the key pair does not exist in the account.')
@@ -55,7 +55,11 @@ def creation_validation(**_):
             raise NonRecoverableError(
                 'Not external resource, '
                 'but the key file exists locally.')
-        if key_pair_in_account:
+        try:
+            _get_key_pair_by_id(ctx.node.properties['resource_id'])
+        except NonRecoverableError:
+            pass
+        else:
             raise NonRecoverableError(
                 'Not external resource, '
                 'but the key pair exists in the account.')

--- a/ec2/tests/test_ec2_instance.py
+++ b/ec2/tests/test_ec2_instance.py
@@ -44,6 +44,7 @@ class TestInstance(testtools.TestCase):
             'resource_id': '',
             'image_id': TEST_AMI_IMAGE_ID,
             'instance_type': TEST_INSTANCE_TYPE,
+            'cloudify_agent': {},
             'parameters': {
                 'security_group_ids': ['sg-73cd3f1e'],
                 'instance_initiated_shutdown_behavior': 'stop'

--- a/ec2/tests/test_ec2_instance.py
+++ b/ec2/tests/test_ec2_instance.py
@@ -142,6 +142,7 @@ class TestInstance(testtools.TestCase):
         ctx = self.mock_ctx('test_start_bad_id')
 
         ctx.instance.runtime_properties['aws_resource_id'] = 'bad_id'
+        ctx.instance.runtime_properties['reservation_id'] = 'r-54ce20b4'
         ex = self.assertRaises(NonRecoverableError,
                                instance.start, ctx=ctx)
         self.assertIn('no instance with id bad_id exists in this account',

--- a/ec2/tests/test_ec2_keypair.py
+++ b/ec2/tests/test_ec2_keypair.py
@@ -153,7 +153,7 @@ class TestKeyPair(testtools.TestCase):
         ex = self.assertRaises(
             NonRecoverableError, keypair.creation_validation, ctx=ctx)
         self.assertIn(
-            'InvalidKeyPair.NotFound',
+            'the key pair does not exist in the account',
             ex.message)
         os.remove(key_path)
 
@@ -176,7 +176,7 @@ class TestKeyPair(testtools.TestCase):
         ex = self.assertRaises(
             NonRecoverableError, keypair.creation_validation, ctx=ctx)
         self.assertIn(
-            'InvalidKeyPair.NotFound',
+            'but the key file exists locally',
             ex.message)
         os.remove(key_path)
 

--- a/ec2/tests/test_ec2_utils.py
+++ b/ec2/tests/test_ec2_utils.py
@@ -93,6 +93,7 @@ class TestUtils(testtools.TestCase):
         output = utils._get_provider_variable_from_file(
             'agents_security_group')
         self.assertIn('agents', output)
+        os.remove(os.path.expanduser('~/.aws_config'))
 
     def test_get_provider_context_empty_file(self):
         ctx = self.mock_ctx('test_get_provider_context')
@@ -104,3 +105,4 @@ class TestUtils(testtools.TestCase):
 
         self.assertEqual({}, utils._get_provider_context(
             os.path.expanduser('~/.aws_config')))
+        os.remove(os.path.expanduser('~/.aws_config'))

--- a/ec2/tests/test_ec2_utils.py
+++ b/ec2/tests/test_ec2_utils.py
@@ -41,6 +41,7 @@ class TestUtils(testtools.TestCase):
             'resource_id': '',
             'image_id': TEST_AMI_IMAGE_ID,
             'instance_type': TEST_INSTANCE_TYPE,
+            'cloudify_agent': {},
             'parameters': {
                 'security_group_ids': ['sg-73cd3f1e'],
                 'instance_initiated_shutdown_behavior': 'stop'
@@ -81,7 +82,7 @@ class TestUtils(testtools.TestCase):
             "agents_security_group": "agents"
         }
 
-        with open(os.path.expanduser('~/.aws_config'), 'w') \
+        with open(os.path.expanduser('~/.aws_config.json'), 'w') \
                 as provider_context_file:
             json.dump(
                 provider_context_json,
@@ -93,16 +94,16 @@ class TestUtils(testtools.TestCase):
         output = utils._get_provider_variable_from_file(
             'agents_security_group')
         self.assertIn('agents', output)
-        os.remove(os.path.expanduser('~/.aws_config'))
+        os.remove(os.path.expanduser('~/.aws_config.json'))
 
     def test_get_provider_context_empty_file(self):
         ctx = self.mock_ctx('test_get_provider_context')
         current_ctx.set(ctx=ctx)
 
-        with open(os.path.expanduser('~/.aws_config'), 'w') \
+        with open(os.path.expanduser('~/.aws_config.json'), 'w') \
                 as provider_context_file:
             provider_context_file.write('')
 
         self.assertEqual({}, utils._get_provider_context(
-            os.path.expanduser('~/.aws_config')))
-        os.remove(os.path.expanduser('~/.aws_config'))
+            os.path.expanduser('~/.aws_config.json')))
+        os.remove(os.path.expanduser('~/.aws_config.json'))

--- a/ec2/utils.py
+++ b/ec2/utils.py
@@ -165,19 +165,23 @@ def get_resource_id():
 
 def get_provider_variables():
 
-    return {
-        "agents_keypair": _get_provider_variable('agents_keypair'),
+    provider_context = {
+        "agents_keypair": _get_variable('agents_keypair'),
         "agents_security_group":
-            _get_provider_variable('agents_security_group'),
-        "manager_keypair": _get_provider_variable('manager_keypair'),
+            _get_variable('agents_security_group'),
+        "manager_keypair": _get_variable('manager_keypair'),
         "manager_security_group":
-            _get_provider_variable('manager_security_group'),
-        "manager_resource_id": _get_provider_variable('manager_resource_id'),
-        "manager_ip_address": _get_provider_variable('manager_ip_address')
+            _get_variable('manager_security_group'),
+        "manager_resource_id": _get_variable('manager_resource_id'),
+        "manager_ip_address": _get_variable('manager_ip_address')
     }
 
+    ctx.logger.info(provider_context)
 
-def _get_provider_variable(variable_name):
+    return provider_context
+
+
+def _get_variable(variable_name):
 
     if variable_name in os.environ:
         return os.environ[variable_name]

--- a/ec2/utils.py
+++ b/ec2/utils.py
@@ -178,12 +178,16 @@ def get_provider_variables():
 
 
 def _get_provider_variable(variable_name):
+
     if variable_name in os.environ:
         return os.environ[variable_name]
-    elif not _get_provider_variable_from_file(variable_name):
+
+    variable_from_file = _get_provider_variable_from_file(variable_name)
+
+    if not variable_from_file:
         return None
-    else:
-        return _get_provider_variable_from_file(variable_name)
+
+    return variable_from_file
 
 
 def _get_provider_variable_from_file(variable_name):
@@ -199,14 +203,12 @@ def _get_provider_variable_from_file(variable_name):
 
 def _get_provider_context_file_path():
 
-    if 'cloudify_agent' in ctx.node.properties and \
-            'home_dir' in ctx.node.properties['cloudify_agent']:
+    if 'home_dir' in ctx.node.properties['cloudify_agent']:
         return os.path.join(
-            os.path.expanduser(
-                ctx.node.properties['cloudify_agent']['home_dir']),
+            ctx.node.properties['cloudify_agent']['home_dir'],
             os.path.split(constants.AWS_CONFIG_PATH)[-1])
-    else:
-        return os.path.expanduser(constants.AWS_CONFIG_PATH)
+
+    return os.path.expanduser(constants.AWS_CONFIG_PATH)
 
 
 def _get_provider_context(aws_configuration):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,7 +6,7 @@ tosca_definitions_version: cloudify_dsl_1_1
 plugins:
   aws:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-aws-plugin/archive/master.zip
+    source: https://github.com/cloudify-cosmo/cloudify-aws-plugin/archive/support_provider_context.zip
 
 node_types:
   cloudify.aws.nodes.Instance:

--- a/system_tests/ec2_handler_configuration.yaml
+++ b/system_tests/ec2_handler_configuration.yaml
@@ -10,11 +10,11 @@ handler: ec2_handler
 
 ######################################################
 # full path to manager blueprint inputs (or provider cloudify-config)
-inputs: resources/inputs.yaml
+inputs: system_tests/resources/inputs.yaml
 
 ######################################################
 # full path to manager blueprint (not required for providers)
-manager_blueprint: resources/manager_blueprint.yaml
+manager_blueprint: system_tests/resources/manager-blueprint.yaml
 
 ######################################################
 # name of handler_properties entry in suites.yaml.

--- a/system_tests/local/ec2_test_utils.py
+++ b/system_tests/local/ec2_test_utils.py
@@ -113,6 +113,7 @@ class EC2LocalTestUtils(testtools.TestCase):
             'resource_id': resource_id_vm,
             'image_id': TEST_AMI,
             'instance_type': TEST_SIZE,
+            'cloudify_agent': {},
             'parameters': {
                 'security_group_ids': [resource_id_sg],
                 'key_name': resource_id_kp

--- a/system_tests/local/test_plugin.py
+++ b/system_tests/local/test_plugin.py
@@ -885,8 +885,12 @@ class EC2InstanceUnitTests(EC2LocalTestUtils):
         ctx = self.mock_cloudify_context(
             'test_get_instance_keypair')
         current_ctx.set(ctx=ctx)
-        output = instance._get_instance_keypair()
-        self.assertEqual([], output)
+        provider_variables = {
+            'agents_keypair': '',
+            'agents_security_group': ''
+        }
+        output = instance._get_instance_keypair(provider_variables)
+        self.assertEqual('', output)
 
     def test_get_instance_parameters(self):
 

--- a/system_tests/resources/manager-blueprint.yaml
+++ b/system_tests/resources/manager-blueprint.yaml
@@ -186,9 +186,11 @@ node_templates:
           implementation: fabric.fabric_plugin.tasks.run_task
           inputs:
             tasks_file: scripts/configure.py
-            task_name: upload_credentials
+            task_name: configure_manager
             task_properties:
               config_path: { get_input: boto_config }
+              agents_security_group: { get_attribute: [ management_security_group, aws_resource_id ] }
+              agents_keypair: { get_attribute: [ management_keypair, aws_resource_id ] }
             fabric_env:
               user: { get_input: manager_server_user }
               key_filename: { get_property: [ management_keypair, private_key_path ] }

--- a/system_tests/resources/manager-blueprint.yaml
+++ b/system_tests/resources/manager-blueprint.yaml
@@ -5,7 +5,7 @@ tosca_definitions_version: cloudify_dsl_1_1
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.2m6/types.yaml
   - http://www.getcloudify.org/spec/fabric-plugin/1.2m6/plugin.yaml
-  - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-aws-plugin/master/plugin.yaml
+  - https://github.com/cloudify-cosmo/cloudify-aws-plugin/tree/support_provider_context
 
 inputs:
 

--- a/system_tests/resources/manager-blueprint.yaml
+++ b/system_tests/resources/manager-blueprint.yaml
@@ -157,12 +157,8 @@ node_templates:
     type: cloudify.nodes.CloudifyManager
     properties:
       cloudify_packages:
-        agents:
-          ubuntu_agent_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m4-RELEASE/cloudify-ubuntu-agent_3.2.0-m4-b173_amd64.deb
-          centos_agent_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m4-RELEASE/cloudify-centos-final-agent_3.2.0-m4-b173_amd64.deb
-          windows_agent_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m4-RELEASE/cloudify-windows-agent_3.2.0-m4-b173_amd64.deb
         docker:
-           docker_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m4-RELEASE/cloudify-docker_3.2.0-m4-b173.tar
+           docker_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m6-RELEASE/cloudify-docker_3.2.0-m6-b176.tar
 
       cloudify:
         resources_prefix: { get_input: resources_prefix }

--- a/system_tests/resources/manager-blueprint.yaml
+++ b/system_tests/resources/manager-blueprint.yaml
@@ -157,6 +157,10 @@ node_templates:
     type: cloudify.nodes.CloudifyManager
     properties:
       cloudify_packages:
+        agents:
+          ubuntu_agent_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m6-RELEASE/cloudify-ubuntu-agent_3.2.0-m6-b176_amd64.deb
+          centos_agent_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m6-RELEASE/cloudify-centos-final-agent_3.2.0-m6-b176_amd64.deb
+          windows_agent_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m6-RELEASE/cloudify-windows-agent_3.2.0-m6-b176_amd64.deb
         docker:
            docker_url: http://gigaspaces-repository-eu.s3.amazonaws.com/org/cloudify3/3.2.0/m6-RELEASE/cloudify-docker_3.2.0-m6-b176.tar
 
@@ -189,8 +193,8 @@ node_templates:
             task_name: configure_manager
             task_properties:
               config_path: { get_input: boto_config }
-              agents_security_group: { get_attribute: [ management_security_group, aws_resource_id ] }
-              agents_keypair: { get_attribute: [ management_keypair, aws_resource_id ] }
+              agents_security_group: { get_attribute: [ agents_security_group, aws_resource_id ] }
+              agents_keypair: { get_attribute: [ agent_keypair, aws_resource_id ] }
             fabric_env:
               user: { get_input: manager_server_user }
               key_filename: { get_property: [ management_keypair, private_key_path ] }
@@ -201,7 +205,7 @@ node_templates:
             task_mapping: cloudify_cli.bootstrap.tasks.bootstrap_docker
             task_properties:
               cloudify_packages: { get_property: [manager, cloudify_packages] }
-              agent_local_key_path: { get_attribute: [agent_keypair, key_path] }
+              agent_local_key_path: { get_attribute: [agent_keypair, private_key_path] }
               provider_context: { get_attribute: [manager, provider_context] }
             fabric_env:
               user: { get_input: manager_server_user }

--- a/system_tests/resources/manager-blueprint.yaml
+++ b/system_tests/resources/manager-blueprint.yaml
@@ -5,7 +5,7 @@ tosca_definitions_version: cloudify_dsl_1_1
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.2m6/types.yaml
   - http://www.getcloudify.org/spec/fabric-plugin/1.2m6/plugin.yaml
-  - https://github.com/cloudify-cosmo/cloudify-aws-plugin/tree/support_provider_context
+  - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-aws-plugin/support_provider_context/plugin.yaml
 
 inputs:
 

--- a/system_tests/resources/scripts/configure.py
+++ b/system_tests/resources/scripts/configure.py
@@ -1,0 +1,39 @@
+########
+# Copyright (c) 2014 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+import os
+import json
+import fabric.api
+from ec2 import configure
+from ec2 import constants
+
+def upload_credentials(config_path):
+    temp = configure.BotoConfig().get_temp_file()
+    fabric.api.put(temp, config_path)
+
+def set_provider_context(agents_security_group, agents_keypair):
+
+    provider_context_json = {
+        "agents_keypair": agents_keypair,
+        "agents_security_group": agents_security_group
+    }
+
+    os.environ['agents_keypair'] = agents_keypair
+    os.environ['agents_security_group'] = agents_security_group
+
+    with open(
+            os.path.expanduser(constants.AWS_CONFIG_PATH), 'w') \
+        as provider_context_file:
+            json.dump(provider_context_json, provider_context_file)

--- a/system_tests/resources/scripts/configure.py
+++ b/system_tests/resources/scripts/configure.py
@@ -19,6 +19,10 @@ import fabric.api
 from ec2 import configure
 from ec2 import constants
 
+def configure_manager(config_path, agents_security_group, agents_keypair):
+    upload_credentials(config_path)
+    set_provider_context(agents_security_group, agents_keypair)
+
 def upload_credentials(config_path):
     temp = configure.BotoConfig().get_temp_file()
     fabric.api.put(temp, config_path)

--- a/system_tests/resources/scripts/configure.py
+++ b/system_tests/resources/scripts/configure.py
@@ -15,6 +15,7 @@
 
 import os
 import json
+import tempfile
 import fabric.api
 from ec2 import configure
 from ec2 import constants
@@ -28,6 +29,7 @@ def upload_credentials(config_path):
     fabric.api.put(temp, config_path)
 
 def set_provider_context(agents_security_group, agents_keypair):
+    temp_config = tempfile.mktemp()
 
     provider_context_json = {
         "agents_keypair": agents_keypair,
@@ -37,7 +39,7 @@ def set_provider_context(agents_security_group, agents_keypair):
     os.environ['agents_keypair'] = agents_keypair
     os.environ['agents_security_group'] = agents_security_group
 
-    with open(
-            os.path.expanduser(constants.AWS_CONFIG_PATH), 'w') \
-        as provider_context_file:
-            json.dump(provider_context_json, provider_context_file)
+    with open(temp_config, 'w') as provider_context_file:
+        json.dump(provider_context_json, provider_context_file)
+
+    fabric.api.put(temp_config, constants.AWS_CONFIG_PATH)


### PR DESCRIPTION
- provide a manner for setting the agent keypair and the agent security group on the manager machine.

- fixed a bug resulting from an earlier change, where the get_keypair_by_id function returned None instead of throwing and error, and modified the creation_validation operation to work with that.

- Finally found a suitable approach for dealing with the Amazon API issue where a "reservation" object with an instance_id that is not in the API is returned. This provides extra validation in the run_instances_if_needed function and the _get_instance_attribute_function