### PR TITLE
switching the name of the nodecellar endpoint node template id

### DIFF
--- a/system_tests/manager/aws_ec2_nodecellar_tests.py
+++ b/system_tests/manager/aws_ec2_nodecellar_tests.py
@@ -37,7 +37,7 @@ class AWSNodeCellarTest(nodecellar_test.NodecellarAppTest):
 
     @property
     def entrypoint_node_name(self):
-        return 'nodecellar_elasticip'
+        return 'nodecellar_ip'
 
     @property
     def entrypoint_property_name(self):


### PR DESCRIPTION
porting this to m5 as it was with master