### PR TITLE
Parse boto file

### DIFF
--- a/ec2/connection.py
+++ b/ec2/connection.py
@@ -13,6 +13,10 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+# Builtin Imports
+import os
+import ConfigParser
+
 # Third-party Imports
 from boto.ec2 import get_region
 from boto.ec2 import EC2Connection
@@ -20,6 +24,7 @@ from boto.ec2 import EC2Connection
 # Cloudify Imports
 from ec2 import utils
 from ec2 import constants
+from cloudify.exceptions import NonRecoverableError
 
 
 class EC2ConnectionClient():
@@ -33,13 +38,17 @@ class EC2ConnectionClient():
         """Represents the EC2Connection Client
         """
 
-        aws_config_property = self._get_aws_config_property()
+        aws_config_property = (self._get_aws_config_property() or
+                               self._get_aws_config_from_file())
         if not aws_config_property:
             return EC2Connection()
         elif aws_config_property.get('ec2_region_name'):
             region_object = \
                 get_region(aws_config_property['ec2_region_name'])
             aws_config = aws_config_property.copy()
+            if region_object and 'ec2_region_endpoint' in aws_config_property:
+                region_object.endpoint = \
+                    aws_config_property['ec2_region_endpoint']
             aws_config['region'] = region_object
         else:
             aws_config = aws_config_property.copy()
@@ -47,9 +56,65 @@ class EC2ConnectionClient():
         if 'ec2_region_name' in aws_config:
             del(aws_config['ec2_region_name'])
 
+        # for backward compatibility,
+        # delete this key before passing config to Boto
+        if 'ec2_region_endpoint' in aws_config:
+            del(aws_config["ec2_region_endpoint"])
+
         return EC2Connection(**aws_config)
 
     def _get_aws_config_property(self):
         node_properties = \
             utils.get_instance_or_source_node_properties()
         return node_properties[constants.AWS_CONFIG_PROPERTY]
+
+    def _get_aws_config_from_file(self):
+        """Get aws config from a Boto cfg file
+        """
+        config_path = self._get_boto_config_file_path()
+        return self._parse_config_file(config_path) if config_path else None
+
+    def _get_boto_config_file_path(self):
+        """Get aws config file path from environment
+        """
+        return os.environ.get(constants.AWS_CONFIG_PATH_ENV_VAR_NAME)
+
+    def _parse_config_file(self, path):
+        """Parse and validate Boto cfg file
+        """
+        path = str(path)
+        if not os.path.isfile(path):
+            raise NonRecoverableError('no aws config file at {0}'.format(path))
+
+        parser = ConfigParser.ConfigParser()
+        parser.read(path)
+
+        if len(parser.sections()) == 0:
+            raise NonRecoverableError("aws config file is empty")
+
+        config_schema = constants.BOTO_CONFIG_SCHEMA
+        config = {}
+
+        # validate sections
+        invalid_sections = \
+            [s for s in parser.sections() if s not in config_schema]
+        if invalid_sections:
+            raise NonRecoverableError("Unsupported Boto section(s): {0}".
+                                      format(', '.join(invalid_sections)))
+
+        # validate options and populate config dict (option > value)
+        invalid_options = []
+
+        for section in parser.sections():
+            allowed_opt_list = config_schema[section]
+            for opt, value in parser.items(section):
+                if opt in allowed_opt_list:
+                    config[opt] = value
+                else:
+                    invalid_options.append((section, opt))
+
+        if invalid_options:
+            raise NonRecoverableError("Unsupported Boto option(s): {0}".
+                                      format(invalid_options))
+
+        return config

--- a/ec2/constants.py
+++ b/ec2/constants.py
@@ -53,3 +53,10 @@ AWS_DEFAULT_CONFIG_PATH = '~/.boto'
 EXTERNAL_RESOURCE_ID = 'aws_resource_id'
 NODE_INSTANCE = 'node-instance'
 RELATIONSHIP_INSTANCE = 'relationship-instance'
+AWS_CONFIG_PATH_ENV_VAR_NAME = "AWS_CONFIG_PATH"
+
+# Boto config schema (section > options)
+BOTO_CONFIG_SCHEMA = {
+    'Credentials': ['aws_access_key_id', 'aws_secret_access_key'],
+    'Boto': ['ec2_region_name', 'ec2_region_endpoint']
+}

--- a/ec2/tests/blueprint/blueprint.yaml
+++ b/ec2/tests/blueprint/blueprint.yaml
@@ -1,6 +1,6 @@
 # DSL version, should appear in the main blueprint.yaml
 # and may appear in other imports. In such case, the versions must match
-tosca_definitions_version: cloudify_dsl_1_1
+tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
     - http://www.getcloudify.org/spec/cloudify/3.3m6/types.yaml

--- a/ec2/tests/test_ec2_parse_config.py
+++ b/ec2/tests/test_ec2_parse_config.py
@@ -1,0 +1,133 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Builtin Imports
+import os
+import tempfile
+from ConfigParser import ConfigParser
+
+# Third Party Imports
+import testtools
+from nose.tools import nottest
+
+# Cloudify Imports
+from ec2 import connection
+from ec2 import constants
+from cloudify.exceptions import NonRecoverableError
+
+
+@nottest
+def test_config(**kwargs):
+    """
+    decorator-generator that can be used on test functions to set
+    key-value pairs that may later be injected into functions using the
+    "inject_test_config" decorator
+    :param kwargs: key-value pairs to be stored on the function object
+    :return: a decorator for a test function, which stores with the test's
+     config on the test function's object under the "test_config" attribute
+    """
+    def _test_config_decorator(test_func):
+        test_func.test_config = kwargs
+        return test_func
+    return _test_config_decorator
+
+
+@nottest
+def inject_test_config(f):
+    """
+    decorator for injecting "test_config" into a test obj method.
+    also see the "test_config" decorator
+    :param f: a test obj method to be injected with the "test_config" parameter
+    :return: the method augmented with the "test_config" parameter
+    """
+    def _wrapper(test_obj, *args, **kwargs):
+        test_func = getattr(test_obj, test_obj.id().split('.')[-1])
+        if hasattr(test_func, 'test_config'):
+            kwargs['test_config'] = test_func.test_config
+        return f(test_obj, *args, **kwargs)
+    return _wrapper
+
+
+class TestParser(testtools.TestCase):
+
+    @inject_test_config
+    def setUp(self, test_config):
+
+        os.environ[constants.AWS_CONFIG_PATH_ENV_VAR_NAME] = \
+            self._generate_config_file(test_config["type"]) \
+            if test_config["type"] != "no_file" \
+            else "/unicorn-bigfoot/pony.cfg"
+
+        super(TestParser, self).setUp()
+
+    def tearDown(self):
+        if constants.AWS_CONFIG_PATH_ENV_VAR_NAME in os.environ:
+            del os.environ[constants.AWS_CONFIG_PATH_ENV_VAR_NAME]
+        super(TestParser, self).tearDown()
+
+    @test_config(type="invalid_section")
+    def test_aws_config_file_invalid_section(self):
+        client = connection.EC2ConnectionClient()
+        self.assertRaisesRegexp(Exception,
+                                'Unsupported Boto section',
+                                client._get_aws_config_from_file)
+
+    @test_config(type="invalid_option")
+    def test_aws_config_file_invalid_option(self):
+        client = connection.EC2ConnectionClient()
+        self.assertRaisesRegexp(Exception,
+                                'Unsupported Boto option',
+                                client._get_aws_config_from_file)
+
+    @test_config(type="valid")
+    def test_aws_config_file_valid(self):
+        client = connection.EC2ConnectionClient()
+        config = client._get_aws_config_from_file()
+
+        config_schema = constants.BOTO_CONFIG_SCHEMA
+        for opt_group in config_schema.values():
+            for opt in opt_group:
+                self.assertIn(opt, config)
+
+    @test_config(type="no_file")
+    def test_aws_config_no_file(self):
+        client = connection.EC2ConnectionClient()
+        self.assertRaises(NonRecoverableError,
+                          client._get_aws_config_from_file)
+
+    def _generate_config_file(self, config_type):
+        """Generate Boto cfg file and return its path
+        """
+
+        __, config_path = tempfile.mkstemp()
+        config = ConfigParser()
+
+        config_schema = constants.BOTO_CONFIG_SCHEMA
+        for section in config_schema:
+            config.add_section(section)
+            for key in config_schema[section]:
+                config.set(section, key, key)
+
+        if config_type == "invalid_option":
+            config.set("Boto", "invalid_option", "foo")
+            config.set("Credentials", "invalid_option2", "foo")
+        if config_type == "invalid_section":
+            config.add_section("invalid_section1")
+            config.add_section("invalid_section2")
+
+        with open(config_path, 'w') as config_file:
+            config.write(config_file)
+
+        return config_path

--- a/system_tests/resources/relationships-blueprint.yaml
+++ b/system_tests/resources/relationships-blueprint.yaml
@@ -1,6 +1,6 @@
 # DSL version, should appear in the main blueprint.yaml
 # and may appear in other imports. In such case, the versions must match
-tosca_definitions_version: cloudify_dsl_1_1
+tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3m6/types.yaml

--- a/system_tests/resources/simple-blueprint.yaml
+++ b/system_tests/resources/simple-blueprint.yaml
@@ -1,6 +1,6 @@
 # DSL version, should appear in the main blueprint.yaml
 # and may appear in other imports. In such case, the versions must match
-tosca_definitions_version: cloudify_dsl_1_1
+tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3m6/types.yaml


### PR DESCRIPTION
As the new manager doesn't use Docker anymore, Boto has an issue reading its configuration file implicitly (.boto file is copied to /home/centos/, whereas the manager expects it at /home/root/)

the issue is solved in two steps:
1) the manager blueprint specifies a custom (preferably non user-specific) path to store the boto file
2) when instantiating a connection, and the aws config property is unavailable, EC2Connection would parse the boto file independently and pass its contents to Boto