### PR TITLE
NEW FEATURE - VPC Support

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,14 @@
+#########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.

--- a/core/base.py
+++ b/core/base.py
@@ -1,0 +1,468 @@
+#########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+# Third-party Imports
+from boto import exception
+
+# Cloudify imports
+from ec2 import utils as ec2_utils
+from ec2 import constants
+from vpc import constants as vpc_constants
+from vpc import connection
+from cloudify.exceptions import NonRecoverableError, RecoverableError
+from cloudify import ctx
+
+
+class AwsBase(object):
+
+    def __init__(self,
+                 client=None
+                 ):
+        self.client = \
+            client if client else connection.VPCConnectionClient().client()
+
+    def execute(self, fn, args=None, raise_on_falsy=False):
+
+        try:
+            output = fn(**args) if args else fn()
+        except (exception.EC2ResponseError,
+                exception.BotoServerError) as e:
+            raise NonRecoverableError('{0}'.format(str(e)))
+
+        if raise_on_falsy and not output:
+            raise NonRecoverableError(
+                'Function {0} returned False.'.format(fn))
+
+        return output
+
+    def get_and_filter_resources_by_matcher(
+            self, filter_function, filters,
+            not_found_token='NotFound'):
+
+        try:
+            list_of_matching_resources = filter_function(**filters)
+        except exception.EC2ResponseError as e:
+            if not_found_token in str(e):
+                return []
+            raise NonRecoverableError('{0}'.format(str(e)))
+        except exception.BotoServerError as e:
+            raise NonRecoverableError('{0}'.format(str(e)))
+
+        return list_of_matching_resources
+
+    def filter_for_single_resource(self, filter_function,
+                                   filters,
+                                   not_found_token='NotFound'):
+
+        resources = self.get_and_filter_resources_by_matcher(
+            filter_function, filters, not_found_token)
+
+        if resources:
+            for resource in resources:
+                if resource.id == filters.values()[0]:
+                    return resource
+
+        return None
+
+    def get_related_targets_and_types(self, relationships):
+        """
+
+        :param relationships: should be ctx.instance.relationships
+        or ctx.source/target.instance.relationships
+        :return: targets_and_types a dict of structure
+        relationship-type: relationship_target_id
+        """
+
+        targets_by_relationship_type = dict()
+
+        if len(relationships) > 0:
+
+            for relationship in relationships:
+                targets_by_relationship_type.update(
+                    {
+                        relationship.type:
+                            relationship.target.instance
+                            .runtime_properties.get(
+                                constants.EXTERNAL_RESOURCE_ID)
+                    }
+                )
+
+        return targets_by_relationship_type
+
+    def get_target_ids_of_relationship_type(
+            self, relationship_type,
+            targets_by_relationship_type):
+
+        target_ids = []
+
+        for current_relationship_type, current_target_id in \
+                targets_by_relationship_type.items():
+
+            if relationship_type in current_relationship_type:
+                target_ids.append(current_target_id)
+
+        return target_ids
+
+    def raise_forbidden_external_resource(self, resource_id):
+        raise NonRecoverableError(
+            'Cannot use_external_resource because resource {0} '
+            'is not in this account.'.format(resource_id))
+
+
+class AwsBaseRelationship(AwsBase):
+
+    def __init__(self, client=None):
+        super(AwsBaseRelationship, self).__init__(client)
+        self.source_resource_id = \
+            ctx.source.instance.runtime_properties.get(
+                constants.EXTERNAL_RESOURCE_ID, None) if \
+            constants.EXTERNAL_RESOURCE_ID in \
+            ctx.source.instance.runtime_properties.keys() else \
+            ctx.source.node.properties['resource_id']
+        self.target_resource_id = ctx.target.instance.runtime_properties.get(
+            constants.EXTERNAL_RESOURCE_ID, None) if \
+            constants.EXTERNAL_RESOURCE_ID in \
+            ctx.target.instance.runtime_properties.keys() else \
+            ctx.target.node.properties['resource_id']
+        self.source_is_external_resource = \
+            ctx.source.node.properties['use_external_resource']
+        self.source_get_all_handler = {'function': None, 'argument': ''}
+
+    def associate(self):
+        return False
+
+    def associated(self):
+
+        ctx.logger.info(
+            'Attempting to associate {0} with {1}.'
+            .format(self.source_resource_id,
+                    self.target_resource_id))
+
+        if self.use_source_external_resource_naively() \
+                or self.associate():
+            return self.post_associate()
+
+        raise NonRecoverableError(
+            'Source is neither external resource, '
+            'nor Cloudify resource, unable to associate {0} with {1}.'
+            .format(self.source_resource_id,
+                    self.target_resource_id))
+
+    def use_source_external_resource_naively(self):
+
+        if not self.source_is_external_resource:
+            return False
+
+        resource = self.get_source_resource()
+
+        if resource is None:
+            self.raise_forbidden_external_resource(
+                self.source_resource_id)
+
+        ctx.logger.info(
+            'Assuming {0} is external, because the user '
+            'specified use_external_resource. Not associating it with {1}.'
+            .format(resource.id, self.target_resource_id))
+
+        return True
+
+    def disassociate(self):
+        return False
+
+    def disassociated(self):
+
+        ctx.logger.info(
+            'Attempting to disassociate {0} from {1}.'
+            .format(self.source_resource_id, self.target_resource_id))
+
+        if self.disassociate_external_resource_naively() \
+                or self.disassociate():
+            return self.post_disassociate()
+
+        raise NonRecoverableError(
+            'Source is neither external resource, '
+            'nor Cloudify resource, unable to disassociate {0} from {1}.'
+            .format(self.source_resource_id, self.target_resource_id))
+
+    def disassociate_external_resource_naively(self):
+
+        if not self.source_is_external_resource:
+            return False
+
+        resource = self.get_source_resource()
+
+        ctx.logger.info(
+            'Assuming {0} is external, because the user '
+            'specified use_external_resource. Not disassociating it with {1}.'
+            .format(resource.id, self.target_resource_id))
+
+        return True
+
+    def post_associate(self):
+        return True
+
+    def post_disassociate(self):
+        return True
+
+    def get_source_resource(self):
+
+        resource = self.filter_for_single_resource(
+            self.source_get_all_handler['function'],
+            {self.source_get_all_handler['argument']: self.source_resource_id},
+        )
+
+        return resource
+
+
+class AwsBaseNode(AwsBase):
+
+    def __init__(self,
+                 aws_resource_type,
+                 required_properties,
+                 client=None
+                 ):
+        super(AwsBaseNode, self).__init__(client)
+
+        def dummy():
+            pass
+
+        self.aws_resource_type = aws_resource_type
+        self.cloudify_node_instance_id = ctx.instance.id
+        self.resource_id = \
+            ctx.instance.runtime_properties.get(
+                constants.EXTERNAL_RESOURCE_ID, None) if \
+            constants.EXTERNAL_RESOURCE_ID in \
+            ctx.instance.runtime_properties.keys() else \
+            ctx.node.properties['resource_id']
+        self.is_external_resource = \
+            ctx.node.properties['use_external_resource']
+        self.required_properties = required_properties
+        self.get_all_handler = {'function': dummy, 'argument': ''}
+        self.not_found_error = ''
+
+    def creation_validation(self):
+        """ This validates all VPC Nodes before bootstrap.
+        """
+
+        resource = self.get_resource()
+
+        for property_key in self.required_properties:
+            ec2_utils.validate_node_property(
+                property_key, ctx.node.properties)
+
+        if self.is_external_resource and not resource:
+            raise NonRecoverableError(
+                'External resource, but the supplied {0} '
+                'does not exist in the account.'
+                .format(self.aws_resource_type))
+
+        if not self.is_external_resource and resource:
+            raise NonRecoverableError(
+                'Not external resource, but the supplied {0}'
+                'exists in the account.'
+                .format(self.aws_resource_type))
+
+    def create(self):
+        return False
+
+    def created(self):
+
+        ctx.logger.info(
+            'Attempting to create {0} {1}.'
+            .format(self.aws_resource_type,
+                    self.cloudify_node_instance_id))
+
+        if self.use_external_resource_naively() or self.create():
+            return self.post_create()
+
+        raise NonRecoverableError(
+            'Neither external resource, nor Cloudify resource, '
+            'unable to create this resource.')
+
+    def use_external_resource_naively(self):
+
+        if not self.is_external_resource:
+            return False
+
+        if not self.get_resource():
+            self.raise_forbidden_external_resource(self.resource_id)
+
+        ctx.logger.info(
+            'Assuming {0} is external, because the user '
+            'specified use_external_resource. Not creating it.'
+            .format(self.aws_resource_type))
+
+        return True
+
+    def delete(self):
+        return False
+
+    def deleted(self):
+
+        ctx.logger.info(
+            'Attempting to delete {0} {1}.'
+            .format(self.aws_resource_type,
+                    self.cloudify_node_instance_id))
+
+        if not self.get_resource():
+            self.raise_forbidden_external_resource(self.resource_id)
+
+        if self.delete_external_resource_naively() or self.delete():
+            return self.post_delete()
+
+        raise NonRecoverableError(
+            'Neither external resource, nor Cloudify resource, '
+            'unable to delete this resource.')
+
+    def delete_external_resource_naively(self):
+
+        if not self.is_external_resource:
+            return False
+
+        ctx.logger.info(
+            'Assuming {0} is external, because the user '
+            'specified use_external_resource. Not deleting {0}.'
+            .format(self.aws_resource_type,
+                    self.resource_id))
+
+        return True
+
+    def get_all_matching(self, list_of_ids=None):
+
+        matches = self.get_and_filter_resources_by_matcher(
+            self.get_all_handler['function'],
+            {self.get_all_handler['argument']: list_of_ids},
+            not_found_token=self.not_found_error
+        )
+
+        return matches
+
+    def get_resource(self):
+
+        resource = self.filter_for_single_resource(
+            self.get_all_handler['function'],
+            {self.get_all_handler['argument']: self.resource_id},
+            not_found_token=self.not_found_error
+        )
+
+        return resource
+
+    def post_create(self):
+
+        ec2_utils.set_external_resource_id(self.resource_id, ctx.instance)
+
+        ctx.logger.info(
+            'Added {0} {1} to Cloudify.'
+            .format(self.aws_resource_type, self.resource_id))
+
+        return True
+
+    def post_delete(self):
+
+        ec2_utils.unassign_runtime_property_from_resource(
+            constants.EXTERNAL_RESOURCE_ID, ctx.instance)
+
+        ctx.logger.info(
+            'Removed {0} {1} from Cloudify.'
+            .format(self.aws_resource_type, self.resource_id))
+
+        return True
+
+
+class RouteMixin(object):
+
+    def create_route(self, route_table_id,
+                     route, route_table_ctx_instance=None):
+
+        route_to_create = dict(
+            route_table_id=route_table_id,
+            destination_cidr_block=route['destination_cidr_block'],
+        )
+
+        if 'gateway_id' in route:
+            route_to_create['gateway_id'] = route['gateway_id']
+        elif 'instance_id' in route:
+            route_to_create['instance_id'] = route['instance_id']
+        elif 'interface_id' in route:
+            route_to_create['interface_id'] = \
+                route['interface_id']
+        elif 'vpc_peering_connection_id' in route:
+            route_to_create['vpc_peering_connection_id'] = \
+                route['vpc_peering_connection_id']
+        else:
+            raise NonRecoverableError(
+                'Unable to create provided route. '
+                'Missing valid values: {0}'.format(route)
+            )
+
+        try:
+            output = self.client.create_route(**route_to_create)
+        except exception.EC2ResponseError as e:
+            if '<Code>RouteAlreadyExists</Code>' in str(e):
+                if route_table_ctx_instance:
+                    self.add_route_to_runtime_properties(
+                        route_table_ctx_instance,
+                        route_to_create)
+                return True
+            else:
+                raise RecoverableError('{0}'.format(str(e)))
+
+        if 'output' not in locals() or not output:
+            raise NonRecoverableError(
+                'create_route failed and no exception was thrown. '
+                'route: {0}'.format(route_to_create)
+            )
+
+        if route_table_ctx_instance:
+            self.add_route_to_runtime_properties(route_table_ctx_instance,
+                                                 route_to_create)
+        return True
+
+    def add_route_to_runtime_properties(self,
+                                        route_table_ctx_instance, route):
+        if 'routes' not in \
+                route_table_ctx_instance.runtime_properties.keys():
+            route_table_ctx_instance.runtime_properties['routes'] = []
+        route_table_ctx_instance.runtime_properties['routes'].append(route)
+
+    def delete_route(self, route_table_id,
+                     route, route_table_ctx_instance=None):
+        args = dict(
+            route_table_id=route_table_id,
+            destination_cidr_block=route['destination_cidr_block']
+        )
+
+        try:
+            output = self.client.delete_route(**args)
+        except exception.EC2ResponseError as e:
+            if vpc_constants.ROUTE_NOT_FOUND_ERROR in str(e):
+                ctx.logger.info(
+                    'Could not delete route: {0} route not '
+                    'found on route_table.'
+                    .format(route, route_table_id))
+                return True
+            raise NonRecoverableError('{0}'.format(str(e)))
+
+        if output:
+            if route_table_ctx_instance:
+                self.remove_route_from_runtime_properties(
+                    route_table_ctx_instance, route)
+            return True
+        return False
+
+    def remove_route_from_runtime_properties(
+            self, route_table_ctx_instance, route):
+        if route in route_table_ctx_instance.runtime_properties['routes']:
+            route_table_ctx_instance.runtime_properties['routes'].remove(route)

--- a/ec2/constants.py
+++ b/ec2/constants.py
@@ -40,12 +40,17 @@ RUN_INSTANCE_PARAMETERS = {
 
 INSTANCE_SECURITY_GROUP_RELATIONSHIP = 'instance_connected_to_security_group'
 INSTANCE_KEYPAIR_RELATIONSHIP = 'instance_connected_to_keypair'
+INSTANCE_SUBNET_RELATIONSHIP = 'instance_contained_in_subnet'
+SECURITY_GROUP_VPC_RELATIONSHIP = 'security_group_contained_in_vpc'
 
 # securitygroup module constants
 SECURITY_GROUP_REQUIRED_PROPERTIES = ['description', 'rules']
 
 # keypair module constants
 KEYPAIR_REQUIRED_PROPERTIES = ['private_key_path']
+
+# elastic ip module contants
+ALLOCATION_ID = 'allocation_id'
 
 # config
 AWS_CONFIG_PROPERTY = 'aws_config'

--- a/ec2/instance.py
+++ b/ec2/instance.py
@@ -188,10 +188,6 @@ def _assign_runtime_properties_to_instance(runtime_properties):
         elif 'public_ip_address' is property_name:
             ctx.instance.runtime_properties[property_name] = \
                 _get_instance_attribute('ip_address')
-        else:
-            attribute = _get_instance_attribute(property_name)
-
-        ctx.logger.debug('Set {0}: {1}.'.format(property_name, attribute))
 
 
 def _instance_started_assign_runtime_properties(instance_id):
@@ -332,8 +328,6 @@ def _terminate_external_instance(instance_id):
 def _get_all_instances(list_of_instance_ids=None):
     """Returns a list of instance objects for a list of instance IDs.
 
-    :param ctx:  The Cloudify ctx context.
-    :param address_id: The ID of an EC2 Instance.
     :returns a list of instance objects.
     :raises NonRecoverableError: If Boto errors.
     """
@@ -364,7 +358,6 @@ def _get_instance_from_id(instance_id):
     """Gets the instance ID of a EC2 Instance
 
     :param instance_id: The ID of an EC2 Instance
-    :param ctx:  The Cloudify ctx context.
     :returns an ID of a an EC2 Instance or None.
     """
 
@@ -399,7 +392,6 @@ def _get_instance_attribute(attribute):
     """Gets an attribute from a boto object that represents an EC2 Instance.
 
     :param attribute: The named python attribute of a boto object.
-    :param ctx:  The Cloudify ctx context.
     :returns python attribute of a boto object representing an EC2 instance.
     :raises NonRecoverableError if constants.EXTERNAL_RESOURCE_ID not set
     :raises NonRecoverableError if no instance is found.
@@ -441,7 +433,6 @@ def _get_instance_attribute(attribute):
 def _get_instance_state():
     """Gets the instance state code of a EC2 Instance
 
-    :param ctx:  The Cloudify ctx context.
     :returns a state code from a boto object representing an EC2 Image.
     """
     state = _get_instance_attribute('state_code')
@@ -451,7 +442,6 @@ def _get_instance_state():
 def _get_instance_parameters():
     """The parameters to the run_instance boto call.
 
-    :param ctx:  The Cloudify ctx context.
     :returns parameters dictionary
     """
 
@@ -470,7 +460,8 @@ def _get_instance_parameters():
         'image_id': ctx.node.properties['image_id'],
         'instance_type': ctx.node.properties['instance_type'],
         'security_group_ids': attached_group_ids,
-        'key_name': _get_instance_keypair(provider_variables)
+        'key_name': _get_instance_keypair(provider_variables),
+        'subnet_id': _get_instance_subnet(provider_variables)
     }
 
     parameters.update(ctx.node.properties['parameters'])
@@ -495,3 +486,19 @@ def _get_instance_keypair(provider_variables):
             'Only one keypair may be attached to an instance.')
 
     return list_of_keypairs[0] if list_of_keypairs else None
+
+
+def _get_instance_subnet(provider_variables):
+
+    list_of_subnets = \
+        utils.get_target_external_resource_ids(
+            constants.INSTANCE_SUBNET_RELATIONSHIP, ctx.instance
+        )
+
+    if not list_of_subnets and provider_variables.get('agents_subnet'):
+        list_of_subnets.append(provider_variables['agents_subnet'])
+    elif len(list_of_subnets) > 1:
+        raise NonRecoverableError(
+            'instance may only be attached to one subnet')
+
+    return list_of_subnets[0] if list_of_subnets else None

--- a/ec2/tests/blueprint/blueprint.yaml
+++ b/ec2/tests/blueprint/blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
     - http://www.getcloudify.org/spec/cloudify/3.3/types.yaml
-    - plugin.yaml
+    - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-aws-plugin/1.3.post1.CFY-4485/plugin.yaml
 
 inputs:
 

--- a/ec2/tests/test_ec2_keypair.py
+++ b/ec2/tests/test_ec2_keypair.py
@@ -215,7 +215,6 @@ class TestKeyPair(testtools.TestCase):
         self.addCleanup(os.remove, key_path)
         with open(key_path, 'w') as out:
             out.write('test_save_keypair')
-        print ctx.node.properties
         ex = self.assertRaises(NonRecoverableError,
                                keypair._save_key_pair, kp)
         self.assertIn(

--- a/ec2/tests/test_ec2_securitygroup.py
+++ b/ec2/tests/test_ec2_securitygroup.py
@@ -323,7 +323,6 @@ class TestSecurityGroup(testtools.TestCase):
             'dummy',
             'this is test')
         ctx.node.properties['rules'][0]['src_group_id'] = group_object
-        print ctx.node.properties['rules']
         ex = self.assertRaises(
             NonRecoverableError,
             securitygroup._create_group_rules,

--- a/system_tests/ec2_handler.py
+++ b/system_tests/ec2_handler.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 
 from boto.ec2 import get_region
 from boto.ec2 import EC2Connection
+from boto.vpc import VPCConnection
 
 from cosmo_tester.framework.handlers import (
     BaseHandler,
@@ -140,15 +141,28 @@ class EC2Handler(BaseHandler):
         credentials = self._client_credentials()
         return EC2Connection(**credentials)
 
+    def vpc_client(self):
+        credentials = self._client_credentials()
+        return VPCConnection(**credentials)
+
     def ec2_infra_state(self):
 
         ec2_client = self.ec2_client()
+        vpc_client = self.vpc_client()
 
         return {
             'instances': dict(self._instances(ec2_client)),
             'key_pairs': dict(self._key_pairs(ec2_client)),
             'elasticips': dict(self._elasticips(ec2_client)),
-            'security_groups': dict(self._security_groups(ec2_client))
+            'security_groups': dict(self._security_groups(ec2_client)),
+            'vpcs': dict(self._vpcs(vpc_client)),
+            'subnets': dict(self._subnets(vpc_client)),
+            'internet_gateways': dict(self._internet_gateways(vpc_client)),
+            'vpn_gateways': dict(self._vpn_gateways(vpc_client)),
+            'customer_gateways': dict(self._customer_gateways(vpc_client)),
+            'network_acls': dict(self._network_acls(vpc_client)),
+            'dhcp_options_sets': dict(self._dhcp_options_sets(vpc_client)),
+            'route_tables': dict(self._route_tables(vpc_client))
         }
 
     def ec2_infra_state_delta(self, before, after):
@@ -163,17 +177,34 @@ class EC2Handler(BaseHandler):
     def remove_ec2_resources(self, resources_to_remove):
 
         ec2_client = self.ec2_client()
+        vpc_client = self.vpc_client()
 
         instances = self._instances(ec2_client)
         key_pairs = self._key_pairs(ec2_client)
         elasticips = self._elasticips(ec2_client)
         security_groups = self._security_groups(ec2_client)
+        vpcs = self._vpcs(vpc_client)
+        subnets = self._subnets(vpc_client)
+        internet_gateways = self._internet_gateways(vpc_client)
+        vpn_gateways = self._vpn_gateways(vpc_client)
+        customer_gateways = self._customer_gateways(vpc_client)
+        network_acls = self._network_acls(vpc_client)
+        dhcp_options_sets = self._dhcp_options_sets(vpc_client)
+        route_tables = self._route_tables(vpc_client)
 
         failed = {
             'instances': {},
             'key_pairs': {},
             'elasticips': {},
-            'security_groups': {}
+            'security_groups': {},
+            'vpcs': {},
+            'subnets': {},
+            'internet_gateways': {},
+            'vpn_gateways': {},
+            'customer_gateways': {},
+            'network_acls': {},
+            'dhcp_options_sets': {},
+            'route_tables': {}
         }
 
         for instance_id, _ in instances:
@@ -198,6 +229,57 @@ class EC2Handler(BaseHandler):
                         security_group_id, failed, 'security_groups'):
                     ec2_client.get_all_security_groups(
                         group_ids=[security_group_id])[0].delete()
+
+        for vpc_id, _ in vpcs:
+            if vpc_id in resources_to_remove['vpcs']:
+                with self._handled_exception(vpc_id, failed, 'vpcs'):
+                    vpc_client.delete_vpc(vpc_id)
+
+        for subnet_id, _ in subnets:
+            if subnet_id in resources_to_remove['subnets']:
+                with self._handled_exception(subnet_id, failed, 'subnets'):
+                    vpc_client.delete_subnet(subnet_id)
+
+        for internet_gateway_id, _ in internet_gateways:
+            if internet_gateway_id in resources_to_remove['internet_gateways']:
+                with self._handled_exception(internet_gateway_id,
+                                             failed,
+                                             'internet_gateways'):
+                    vpc_client.delete_internet_gateway(internet_gateway_id)
+
+        for vpn_gateway_id, _ in vpn_gateways:
+            if vpn_gateway_id in resources_to_remove['vpn_gateways']:
+                with self._handled_exception(vpn_gateway_id,
+                                             failed,
+                                             'vpn_gateways'):
+                    vpc_client.delete_vpn_gateway(vpn_gateway_id)
+
+        for customer_gateway_id, _ in customer_gateways:
+            if customer_gateway_id in resources_to_remove['customer_gateways']:
+                with self._handled_exception(customer_gateway_id,
+                                             failed,
+                                             'customer_gateways'):
+                    vpc_client.delete_customer_gateway(customer_gateway_id)
+
+        for network_acl_id, _ in network_acls:
+            if network_acl_id in resources_to_remove['network_acls']:
+                with self._handled_exception(network_acl_id,
+                                             failed,
+                                             'network_acls'):
+                    vpc_client.delete_network_acl(network_acl_id)
+
+        for dhcp_options_set_id, _ in dhcp_options_sets:
+            if dhcp_options_set_id in resources_to_remove['dhcp_options_sets']:
+                with self._handled_exception(dhcp_options_set_id,
+                                             failed,
+                                             'dhcp_options_sets'):
+                    vpc_client.delete_dhcp_options(dhcp_options_set_id)
+
+        for route_table_id, _ in route_tables:
+            if route_table_id in resources_to_remove['route_tables']:
+                with self._handled_exception(route_table_id, failed,
+                                             'route_tables'):
+                    vpc_client.delete_route_table(route_table_id)
 
         return failed
 
@@ -227,6 +309,38 @@ class EC2Handler(BaseHandler):
     def _elasticips(self, ec2_client):
         return [(address.public_ip, address.public_ip)
                 for address in ec2_client.get_all_addresses()]
+
+    def _vpcs(self, vpc_client):
+        return [(vpc.id, vpc.id)
+                for vpc in vpc_client.get_all_vpcs()]
+
+    def _subnets(self, vpc_client):
+        return [(subnet.id, subnet.id)
+                for subnet in vpc_client.get_all_subnets()]
+
+    def _internet_gateways(self, vpc_client):
+        return [(internet_gateway.id, internet_gateway.id)
+                for internet_gateway in vpc_client.get_all_internet_gateways()]
+
+    def _vpn_gateways(self, vpc_client):
+        return [(vpn_gateway.id, vpn_gateway.id)
+                for vpn_gateway in vpc_client.get_all_vpn_gateways()]
+
+    def _customer_gateways(self, vpc_client):
+        return [(customer_gateway.id, customer_gateway.id)
+                for customer_gateway in vpc_client.get_all_customer_gateways()]
+
+    def _network_acls(self, vpc_client):
+        return [(network_acl.id, network_acl.id)
+                for network_acl in vpc_client.get_all_network_acls()]
+
+    def _dhcp_options_sets(self, vpc_client):
+        return [(dhcp_options_set.id, dhcp_options_set.id)
+                for dhcp_options_set in vpc_client.get_all_dhcp_options()]
+
+    def _route_tables(self, vpc_client):
+        return [(route_table.id, route_table.id)
+                for route_table in vpc_client.get_all_route_tables()]
 
     def _remove_keys(self, dct, keys):
         for key in keys:

--- a/system_tests/local/test_vpc.py
+++ b/system_tests/local/test_vpc.py
@@ -1,0 +1,166 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Built in Imports
+from copy import deepcopy
+from time import sleep
+
+# Third Party Imports
+from fabric import api as fabric_api
+
+# Cloudify Imports
+from vpc import constants
+from .vpc_test_utils import TestVpcBase
+from cloudify.workflows import local
+
+IGNORED_LOCAL_WORKFLOW_MODULES = (
+    'worker_installer.tasks',
+    'plugin_installer.tasks',
+    'cloudify_agent.operations',
+    'cloudify_agent.installer.operations',
+)
+
+EC2_RESOURCES = [
+    'cloudify.aws.nodes.SecurityGroup',
+    'cloudify.aws.nodes.KeyPair',
+    'cloudify.aws.nodes.ElasticIP',
+    'cloudify.aws.nodes.Instance'
+]
+
+
+class TestVpc(TestVpcBase):
+
+    def test_install_workflow(self):
+        vpc_client = self.vpc_client()
+        dumb_vpc = vpc_client.create_vpc('11.0.0.0/16')
+        self.addCleanup(vpc_client.delete_vpc, dumb_vpc.id)
+        override_inputs = dict(
+            vpc_id=dumb_vpc.id,
+            vpc_two_create_new_resource=True
+        )
+        cfy_local = local.init_env(
+            self.get_blueprint_path(),
+            name='test_install_workflow',
+            inputs=self.get_inputs(override_inputs=override_inputs),
+            ignored_modules=IGNORED_LOCAL_WORKFLOW_MODULES)
+        cfy_local.execute('install', task_retries=10)
+        self.addCleanup(cfy_local.execute, 'uninstall', task_retries=10)
+        node_instances = cfy_local.storage.get_node_instances()
+        current_resources = self.get_current_list_of_used_resources(vpc_client)
+        for node_instance in node_instances:
+            node = cfy_local.storage.get_node(node_instance.node_id)
+            if node.type in EC2_RESOURCES:
+                continue
+            actual_resource_id = \
+                node_instance.runtime_properties['aws_resource_id']
+            expected_resource_ids = \
+                [resource.id for resource in current_resources[node.type]]
+            self.assertIn(actual_resource_id, expected_resource_ids)
+
+        cloudify_aws_vpc = \
+            cfy_local.storage.get_node_instances(node_id='vpc_one')
+        cloudify_aws_vpc_id = \
+            cloudify_aws_vpc[0].runtime_properties['aws_resource_id']
+        vpc = self.vpc_client().get_all_vpcs(vpc_ids=[cloudify_aws_vpc_id])
+        cloudify_aws_dhcp = \
+            cfy_local.storage.get_node_instances(
+                node_id='dhcp_options_one')
+        cloudify_aws_dhcp_options_id = \
+            cloudify_aws_dhcp[0].runtime_properties['aws_resource_id']
+        dhcp_options_sets = \
+            self.vpc_client().get_all_dhcp_options(
+                dhcp_options_ids=[cloudify_aws_dhcp_options_id])
+
+        self.assertIn(vpc[0].dhcp_options_id, dhcp_options_sets[0].id)
+        self.assertIn('10.0.0.0/16', vpc[0].cidr_block)
+
+        key_node = cfy_local.storage.get_node('key_one')
+        elastic_ip_node = \
+            cfy_local.storage.get_node_instances(node_id='elastic_ip_one')
+        ec2_instance_two = \
+            cfy_local.storage.get_node_instances(node_id='ec2_instance_two')
+        connection = dict(
+            user='ubuntu',
+            key_filename=key_node.properties['private_key_path'],
+            host_string=elastic_ip_node[0].runtime_properties[
+                'aws_resource_id'],
+            connection_attempts=10,
+            command_timeout=30
+        )
+
+        with fabric_api.settings(**connection):
+            instance_one_assertion = fabric_api.run('uname -a')
+
+        try:
+            with fabric_api.settings(**connection):
+                fabric_api.put(
+                    key_node.properties['private_key_path'],
+                    '~/.ssh/key.pem'
+                )
+                fabric_api.run('chmod 600 ~/.ssh/key.pem')
+                instance_two_assertion = \
+                    fabric_api.run(
+                        'ssh -o "StrictHostKeyChecking no" '
+                        '-i ~/.ssh/key.pem ubuntu@{0} /bin/uname -a'
+                        .format(ec2_instance_two[0].runtime_properties['ip']))
+        except SystemExit:
+            sleep(10)
+            with fabric_api.settings(**connection):
+                fabric_api.put(
+                    key_node.properties['private_key_path'],
+                    '~/.ssh/key.pem'
+                )
+                fabric_api.run('chmod 600 ~/.ssh/key.pem')
+                instance_two_assertion = \
+                    fabric_api.run(
+                        'ssh -o "StrictHostKeyChecking no" '
+                        '-i ~/.ssh/key.pem ubuntu@{0} /bin/uname -a'
+                        .format(ec2_instance_two[0].runtime_properties['ip']))
+
+        self.assertIn('Ubuntu', instance_one_assertion)
+        self.assertIn('Ubuntu', instance_two_assertion)
+
+    def test_uninstall_workflow(self):
+        cfy_local = local.init_env(
+            self.get_blueprint_path(),
+            name='test_uninstall_workflow',
+            inputs=self.get_inputs(),
+            ignored_modules=IGNORED_LOCAL_WORKFLOW_MODULES)
+        cfy_local.execute('install', task_retries=10)
+        node_instances = cfy_local.storage.get_node_instances()
+        copy_node_instances = deepcopy(node_instances)
+        cfy_local.execute('uninstall', task_retries=10)
+        vpc_client = self.vpc_client()
+        current_resources = self.get_current_list_of_used_resources(vpc_client)
+        for node_instance in copy_node_instances:
+            node = cfy_local.storage.get_node(node_instance.node_id)
+            if node.type in EC2_RESOURCES:
+                continue
+            actual_resource_id = \
+                node_instance.runtime_properties['aws_resource_id']
+            expected_resource_ids = \
+                [resource.id for resource in current_resources[node.type]]
+            if node.type in constants.CUSTOMER_GATEWAY['CLOUDIFY_NODE_TYPE']:
+                customer_gateway = \
+                    vpc_client.get_all_customer_gateways(
+                        customer_gateway_ids=actual_resource_id)
+                self.assertIn(customer_gateway[0].state,
+                              ['detached', 'deleted'])
+            elif node.type in constants.VPN_GATEWAY['CLOUDIFY_NODE_TYPE']:
+                vpn_gateway = vpc_client.get_all_vpn_gateways(
+                    vpn_gateway_ids=actual_resource_id)
+                self.assertIn(vpn_gateway[0].state, ['detached', 'deleted'])
+            else:
+                self.assertNotIn(actual_resource_id, expected_resource_ids)

--- a/system_tests/local/vpc_test_utils.py
+++ b/system_tests/local/vpc_test_utils.py
@@ -1,0 +1,101 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Built-in Imports
+import os
+# import testtools
+
+# Third Party Imports
+from boto.vpc import VPCConnection
+from boto.ec2 import get_region
+
+# Cloudify Imports
+from vpc import constants
+from cosmo_tester.framework.testenv import TestCase
+
+
+class TestVpcBase(TestCase):
+
+    def get_blueprint_path(self,
+                           blueprint_name='vpc_test_blueprint.yaml'):
+
+        path = os.path.join(
+            os.path.dirname(
+                os.path.dirname(__file__)
+            ),
+            'manager/resources',
+            blueprint_name)
+        return path
+
+    def get_inputs(self, override_inputs=None):
+
+        inputs = dict(
+            aws_config=self._get_aws_config(),
+            create_new_resource=False,
+            vpc_two_create_new_resource=False,
+            vpc_id='',
+            subnet_id='',
+            internet_gateway_id='',
+            ami_id=self.env.ubuntu_trusty_image_id,
+            instance_type=self.env.micro_instance_type,
+            vpn_gateway_id='',
+            customer_gateway_id='',
+            acl_list_id='',
+            dhcp_options_id='',
+            route_table_id='',
+            availability_zone=self.env.availability_zone,
+            dhcp_options_domain_name=self.env.ec2_domain_name,
+            dhcp_options_domain_name_servers='AmazonProvidedDNS'
+        )
+        if override_inputs:
+            inputs.update(override_inputs)
+        return inputs
+
+    def _get_aws_config(self):
+
+        region = get_region(self.env.ec2_region_name)
+
+        return {
+            'aws_access_key_id': self.env.aws_access_key_id,
+            'aws_secret_access_key': self.env.aws_secret_access_key,
+            'region': region
+        }
+
+    def vpc_client(self):
+        credentials = self._get_aws_config()
+        return VPCConnection(**credentials)
+
+    def get_current_list_of_used_resources(self, vpc_client):
+
+        resources = {
+            constants.VPC['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_vpcs(),
+            constants.SUBNET['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_subnets(),
+            constants.INTERNET_GATEWAY['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_internet_gateways(),
+            constants.VPN_GATEWAY['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_vpn_gateways(),
+            constants.NETWORK_ACL['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_network_acls(),
+            constants.DHCP_OPTIONS['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_dhcp_options(),
+            constants.CUSTOMER_GATEWAY['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_customer_gateways(),
+            constants.ROUTE_TABLE['CLOUDIFY_NODE_TYPE']:
+                vpc_client.get_all_route_tables()
+        }
+
+        return resources

--- a/system_tests/manager/aws_ec2_user_data_agent_install_test.py
+++ b/system_tests/manager/aws_ec2_user_data_agent_install_test.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 
 import os
-import time
 
 from cosmo_tester.framework.testenv import TestCase
 

--- a/system_tests/manager/resources/relationships-blueprint.yaml
+++ b/system_tests/manager/resources/relationships-blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3/types.yaml
-  - http://www.getcloudify.org/spec/aws-plugin/1.3/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-aws-plugin/1.3.post1.CFY-4485/plugin.yaml
 
 inputs:
 

--- a/system_tests/manager/resources/simple-blueprint.yaml
+++ b/system_tests/manager/resources/simple-blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3/types.yaml
-  - http://www.getcloudify.org/spec/aws-plugin/1.3/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-aws-plugin/1.3.post1.CFY-4485/plugin.yaml
 
 inputs:
 

--- a/system_tests/manager/resources/user-data-agent-install-blueprint.yaml
+++ b/system_tests/manager/resources/user-data-agent-install-blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3/types.yaml
-  - http://www.getcloudify.org/spec/aws-plugin/1.3/plugin.yaml
+  - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-aws-plugin/1.3.post1.CFY-4485/plugin.yaml
 
 inputs:
 

--- a/system_tests/manager/resources/vpc_test_blueprint.yaml
+++ b/system_tests/manager/resources/vpc_test_blueprint.yaml
@@ -1,0 +1,311 @@
+# DSL version, should appear in the main blueprint.yaml
+# and may appear in other imports. In such case, the versions must match
+tosca_definitions_version: cloudify_dsl_1_2
+
+imports:
+  - http://www.getcloudify.org/spec/cloudify/3.3/types.yaml
+  - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-aws-plugin/1.3.post1.CFY-4485/plugin.yaml
+
+inputs:
+
+  aws_config:
+    default: {}
+
+  create_new_resource:
+    type: boolean
+    default: false
+
+  vpc_two_create_new_resource:
+    type: boolean
+    default: false
+
+  vpc_id:
+    type: string
+    default: ''
+
+  subnet_id:
+    type: string
+    default: ''
+
+  internet_gateway_id:
+    type: string
+    default: ''
+
+  ami_id:
+    type: string
+    default: 'ami-3cf8b154'
+
+  instance_type:
+    type: string
+    default: 'm3.medium'
+
+  vpn_gateway_id:
+    type: string
+    default: ''
+
+  customer_gateway_id:
+    type: string
+    default: ''
+
+  acl_list_id:
+    type: string
+    default: ''
+
+  dhcp_options_id:
+    type: string
+    default: ''
+
+  route_table_id:
+    type: string
+    default: ''
+
+  availability_zone:
+    type: string
+    default: 'us-east-1e'
+
+  dhcp_options_domain_name:
+    type: string
+    default: 'ec2.internal'
+
+  dhcp_options_domain_name_servers:
+    default: 'AmazonProvidedDNS'
+
+node_templates:
+
+  vpc_one:
+    type: cloudify.aws.nodes.VPC
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: vpc_id }
+      cidr_block: 10.0.0.0/16
+
+  subnet_one:
+    type: cloudify.aws.nodes.Subnet
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: subnet_id }
+      cidr_block: 10.0.0.0/24
+      availability_zone: { get_input: availability_zone }
+    relationships:
+      - type: cloudify.aws.relationships.subnet_contained_in_vpc
+        target: vpc_one
+
+  vpc_two:
+    type: cloudify.aws.nodes.VPC
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: vpc_two_create_new_resource }
+      resource_id: { get_input: vpc_id }
+      cidr_block: 11.0.0.0/16
+
+  subnet_two:
+    type: cloudify.aws.nodes.Subnet
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: subnet_id }
+      cidr_block: 11.0.0.0/24
+      availability_zone: { get_input: availability_zone }
+    relationships:
+      - type: cloudify.aws.relationships.subnet_contained_in_vpc
+        target: vpc_two
+
+  internet_gateway_one:
+    type: cloudify.aws.nodes.InternetGateway
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: internet_gateway_id }
+    relationships:
+      - type: cloudify.aws.relationships.gateway_connected_to_vpc
+        target: vpc_one
+
+  security_group_one:
+    type: cloudify.aws.nodes.SecurityGroup
+    properties:
+      aws_config: { get_input: aws_config }
+      description: vpc system test security group
+      rules:
+        - ip_protocol: tcp
+          from_port: 22
+          to_port: 22
+          cidr_ip: 0.0.0.0/0
+    relationships:
+      - type: cloudify.aws.relationships.security_group_contained_in_vpc
+        target: vpc_one
+
+  security_group_two:
+    type: cloudify.aws.nodes.SecurityGroup
+    properties:
+      aws_config: { get_input: aws_config }
+      description: vpc system test security group two
+      rules:
+        - ip_protocol: tcp
+          from_port: 22
+          to_port: 22
+          cidr_ip: 0.0.0.0/0
+    relationships:
+      - type: cloudify.aws.relationships.security_group_contained_in_vpc
+        target: vpc_two
+
+  key_one:
+    type: cloudify.aws.nodes.KeyPair
+    properties:
+      aws_config: { get_input: aws_config }
+      private_key_path: ~/.ssh/vpc_system_test.pem
+
+  elastic_ip_one:
+    type: cloudify.aws.nodes.ElasticIP
+    properties:
+      aws_config: { get_input: aws_config }
+      domain: vpc
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: internet_gateway_one
+
+  ec2_instance_one:
+    type: cloudify.aws.nodes.Instance
+    properties:
+      aws_config: { get_input: aws_config }
+      image_id: { get_input: ami_id }
+      instance_type: { get_input: instance_type }
+      install_agent: false
+      parameters:
+        placement: { get_property: [ subnet_one, availability_zone ] }
+    relationships:
+      - type: cloudify.aws.relationships.instance_contained_in_subnet
+        target: subnet_one
+      - type: cloudify.aws.relationships.instance_connected_to_security_group
+        target: security_group_one
+      - type: cloudify.aws.relationships.instance_connected_to_keypair
+        target: key_one
+      - type: cloudify.aws.relationships.instance_connected_to_elastic_ip
+        target: elastic_ip_one
+
+  ec2_instance_two:
+    type: cloudify.aws.nodes.Instance
+    properties:
+      aws_config: { get_input: aws_config }
+      image_id: { get_input: ami_id }
+      instance_type: { get_input: instance_type }
+      install_agent: false
+      parameters:
+        placement: { get_property: [ subnet_one, availability_zone ] }
+    relationships:
+      - type: cloudify.aws.relationships.instance_contained_in_subnet
+        target: subnet_two
+      - type: cloudify.aws.relationships.instance_connected_to_security_group
+        target: security_group_two
+      - type: cloudify.aws.relationships.instance_connected_to_keypair
+        target: key_one
+
+  vpn_gateway_one:
+    type: cloudify.aws.nodes.VPNGateway
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: vpn_gateway_id }
+      availability_zone: { get_input: availability_zone }
+    relationships:
+      - type: cloudify.aws.relationships.gateway_connected_to_vpc
+        target: vpc_one
+
+  customer_gateway_one:
+    type: cloudify.aws.nodes.CustomerGateway
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: customer_gateway_id }
+      ip_address: 62.90.11.161
+      bgp_asn: 65534
+    relationships:
+      - type: cloudify.aws.relationships.customer_gateway_connected_to_vpn_gateway
+        target: vpn_gateway_one
+
+  acl_one:
+    type: cloudify.aws.nodes.ACL
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: acl_list_id }
+      acl_network_entries:
+        - rule_number: 101
+          protocol: 6
+          rule_action: ALLOW
+          cidr_block: 0.0.0.0/0
+          egress: ''
+          icmp_code: ''
+          icmp_type: ''
+          port_range_from: 0
+          port_range_to: 65535
+        - rule_number: 201
+          protocol: 6
+          rule_action: ALLOW
+          cidr_block: 0.0.0.0/0
+          egress: true
+          icmp_code: ''
+          icmp_type: ''
+          port_range_from: 0
+          port_range_to: 65535
+    relationships:
+      - type: cloudify.aws.relationships.network_acl_contained_in_vpc
+        target: vpc_one
+      - type: cloudify.aws.relationships.network_acl_associated_with_subnet
+        target: subnet_one
+
+  dhcp_options_one:
+    type: cloudify.aws.nodes.DHCPOptions
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: dhcp_options_id }
+      domain_name: { get_input: dhcp_options_domain_name }
+      domain_name_servers: { get_input: dhcp_options_domain_name_servers }
+    relationships:
+      - type: cloudify.aws.relationships.dhcp_options_associated_with_vpc
+        target: vpc_one
+
+  route_table_one:
+    type: cloudify.aws.nodes.RouteTable
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: route_table_id }
+    relationships:
+      - type: cloudify.aws.relationships.routetable_contained_in_vpc
+        target: vpc_one
+      - type: cloudify.aws.relationships.routetable_associated_with_subnet
+        target: subnet_one
+      - type: cloudify.aws.relationships.route_table_to_gateway
+        target: internet_gateway_one
+      - type: cloudify.aws.relationships.route_table_of_source_vpc_connected_to_target_peer_vpc
+        target: vpc_two
+        target_interfaces:
+          cloudify.interfaces.relationship_lifecycle:
+            preconfigure:
+              implementation: aws.vpc.vpc.create_vpc_peering_connection
+              inputs:
+                target_account_id: '535075449278'
+                routes:
+                    - destination_cidr_block: { get_property: [ vpc_two, cidr_block ] }
+      - type: cloudify.relationship.depends_on
+        target: route_table_two
+
+  route_table_two:
+    type: cloudify.aws.nodes.RouteTable
+    properties:
+      aws_config: { get_input: aws_config }
+      use_external_resource: { get_input: create_new_resource }
+      resource_id: { get_input: route_table_id }
+    relationships:
+      - type: cloudify.aws.relationships.routetable_contained_in_vpc
+        target: vpc_two
+      - type: cloudify.aws.relationships.routetable_associated_with_subnet
+        target: subnet_two
+
+plugins:
+    ec2:
+        executor: central_deployment_agent
+        install: false

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,5 @@ testtools
 nose
 nose-cov
 testfixtures
-moto==0.4.4
+https://github.com/EarthmanT/moto/archive/master.zip
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,14 @@ envlist=flake8,py27
 deps =
     -rdev-requirements.txt
     -rtest-requirements.txt
-commands=nosetests -v --nocapture --nologcapture --with-cov --cov-report term-missing --cov ec2 ec2/tests
+commands =
+    nosetests -v --nocapture --nologcapture --with-cov --cov-report term-missing --cov ec2 ec2/tests
+    nosetests -v --nocapture --nologcapture --with-cov --cov-report term-missing --cov vpc vpc/tests
 
 [testenv:flake8]
 deps =
     flake8
     -rdev-requirements.txt
-commands=flake8 ec2
+commands =
+    flake8 ec2
+    flake8 vpc

--- a/vpc/__init__.py
+++ b/vpc/__init__.py
@@ -1,0 +1,14 @@
+#########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.

--- a/vpc/connection.py
+++ b/vpc/connection.py
@@ -1,0 +1,64 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Third-party Imports
+from boto.ec2 import get_region
+from boto.vpc import VPCConnection
+
+# Cloudify imports
+from ec2.connection import EC2ConnectionClient
+from ec2 import utils as ec2_utils
+from ec2 import constants
+
+
+class VPCConnectionClient(EC2ConnectionClient):
+    """Provides functions for getting the VPC Client
+    """
+
+    def client(self, aws_config=None):
+        """Represents the VPCConnection Client
+        """
+
+        aws_config_property = (self._get_aws_config_property(aws_config) or
+                               self._get_aws_config_from_file())
+        if not aws_config_property:
+            return VPCConnection()
+        elif aws_config_property.get('ec2_region_name'):
+            region_object = \
+                get_region(aws_config_property['ec2_region_name'])
+            aws_config = aws_config_property.copy()
+            if region_object and 'ec2_region_endpoint' in aws_config_property:
+                region_object.endpoint = \
+                    aws_config_property['ec2_region_endpoint']
+            aws_config['region'] = region_object
+        else:
+            aws_config = aws_config_property.copy()
+
+        if 'ec2_region_name' in aws_config:
+            del(aws_config['ec2_region_name'])
+
+        # for backward compatibility,
+        # delete this key before passing config to Boto
+        if 'ec2_region_endpoint' in aws_config:
+            del(aws_config["ec2_region_endpoint"])
+
+        return VPCConnection(**aws_config)
+
+    def _get_aws_config_property(self, aws_config=None):
+        if aws_config:
+            return aws_config
+        node_properties = \
+            ec2_utils.get_instance_or_source_node_properties()
+        return node_properties[constants.AWS_CONFIG_PROPERTY]

--- a/vpc/constants.py
+++ b/vpc/constants.py
@@ -1,0 +1,104 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+EXTERNAL_RESOURCE_ID = 'aws_resource_id'
+AVAILABILITY_ZONE = 'availability_zone'
+AWS_CONFIG_PROPERTY = 'aws_config'
+ROUTE_NOT_FOUND_ERROR = 'InvalidRoute.NotFound'
+
+VPC = dict(
+    AWS_RESOURCE_TYPE='vpc',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.VPC',
+    ID_FORMAT='^vpc\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidVpcID.NotFound',
+    REQUIRED_PROPERTIES=['cidr_block', 'instance_tenancy']
+)
+
+SUBNET = dict(
+    AWS_RESOURCE_TYPE='subnet',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.Subnet',
+    ID_FORMAT='^subnet\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidSubnetID.NotFound',
+    REQUIRED_PROPERTIES=['cidr_block']
+)
+
+ROUTE_TABLE = dict(
+    AWS_RESOURCE_TYPE='route_table',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.RouteTable',
+    ID_FORMAT='^rtb\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidRouteTableID.NotFound',
+    REQUIRED_PROPERTIES=[]
+)
+
+NETWORK_ACL = dict(
+    AWS_RESOURCE_TYPE='network_acl',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.ACL',
+    ID_FORMAT='^acl\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidNetworkAclID.NotFound',
+    REQUIRED_PROPERTIES=[]
+)
+
+INTERNET_GATEWAY = dict(
+    AWS_RESOURCE_TYPE='internet_gateway',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.InternetGateway',
+    ID_FORMAT='^igw\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidInternetGatewayID.NotFound',
+    REQUIRED_PROPERTIES=[]
+)
+
+VPN_GATEWAY = dict(
+    AWS_RESOURCE_TYPE='vpn_gateway',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.VPNGateway',
+    ID_FORMAT='^vgw\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidVpnGatewayID.NotFound',
+    REQUIRED_PROPERTIES=[]
+)
+
+CUSTOMER_GATEWAY = dict(
+    AWS_RESOURCE_TYPE='customer_gateway',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.CustomerGateway',
+    ID_FORMAT='^cgw\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidCustomerGatewayID.NotFound',
+    REQUIRED_PROPERTIES=[]
+)
+
+DHCP_OPTIONS = dict(
+    AWS_RESOURCE_TYPE='dhcp_options',
+    CLOUDIFY_NODE_TYPE='cloudify.aws.nodes.DHCPOptions',
+    ID_FORMAT='^dopt\-[0-9a-z]{8}$',
+    NOT_FOUND_ERROR='InvalidDhcpOptionID.NotFound',
+    REQUIRED_PROPERTIES=[]
+)
+
+GATEWAY_VPC_RELATIONSHIP = \
+    'cloudify.aws.relationships.gateway_connected_to_vpc'
+SUBNET_IN_VPC = \
+    'cloudify.aws.relationships.subnet_contained_in_vpc'
+ROUTE_TABLE_VPC_RELATIONSHIP = \
+    'cloudify.aws.relationships.routetable_contained_in_vpc'
+ROUTE_TABLE_GATEWAY_RELATIONSHIP = \
+    'cloudify.aws.relationships.route_table_to_gateway'
+INSTANCE_VPC_RELATIONSHIP = \
+    'cloudify.aws.relationships.instance_connected_to_vpc'
+NETWORK_ACL_IN_VPC_RELATIONSHIP = \
+    'cloudify.aws.relationships.network_acl_contained_in_vpc'
+NETWORK_ACL_IN_SUBNET_RELATIONSHIP = \
+    'cloudify.aws.relationships.network_acl_associated_with_subnet'
+VPC_PEERING_RELATIONSHIP = \
+    'cloudify.aws.relationships.vpc_connected_to_peer'
+DHCP_VPC_RELATIONSHIP = \
+    'cloudify.aws.relationships.dhcp_options_associated_with_vpc'
+CUSTOMER_VPC_RELATIONSHIP = \
+    'cloudify.aws.relationships.customer_gateway_connected_to_vpn_gateway'

--- a/vpc/dhcp.py
+++ b/vpc/dhcp.py
@@ -1,0 +1,113 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Cloudify imports
+from . import constants
+from core.base import AwsBaseNode, AwsBaseRelationship
+from cloudify import ctx
+from cloudify.decorators import operation
+
+
+@operation
+def creation_validation(**_):
+    return DhcpOptions().creation_validation()
+
+
+@operation
+def create_dhcp_options(**_):
+    return DhcpOptions().created()
+
+
+@operation
+def delete_dhcp_options(**_):
+    return DhcpOptions().deleted()
+
+
+@operation
+def associate_dhcp_options(**_):
+    return DhcpAssociation().associated()
+
+
+@operation
+def restore_dhcp_options(**_):
+    return DhcpAssociation().disassociated()
+
+
+class DhcpAssociation(AwsBaseRelationship):
+
+    def __init__(self):
+        super(DhcpAssociation, self).__init__()
+        self.source_get_all_handler = {
+            'function': self.client.get_all_dhcp_options,
+            'argument':
+            '{0}_ids'.format(constants.DHCP_OPTIONS['AWS_RESOURCE_TYPE'])
+        }
+
+    def associate(self):
+        associate_args = dict(
+            dhcp_options_id=self.source_resource_id,
+            vpc_id=self.target_resource_id
+        )
+        return self.execute(self.client.associate_dhcp_options,
+                            associate_args, raise_on_falsy=True)
+
+    def disassociate(self):
+        disassociate_args = self.generate_disassociate_args()
+        return self.execute(self.client.associate_dhcp_options,
+                            disassociate_args, raise_on_falsy=True)
+
+    def generate_disassociate_args(self):
+
+        return dict(
+            dhcp_options_id=ctx.target.instance.runtime_properties[
+                'default_dhcp_options_id'],
+            vpc_id=self.target_resource_id
+        )
+
+
+class DhcpOptions(AwsBaseNode):
+
+    def __init__(self):
+        super(DhcpOptions, self).__init__(
+            constants.DHCP_OPTIONS['AWS_RESOURCE_TYPE'],
+            constants.DHCP_OPTIONS['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.DHCP_OPTIONS['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_dhcp_options,
+            'argument':
+            '{0}_ids'.format(constants.DHCP_OPTIONS['AWS_RESOURCE_TYPE'])
+        }
+
+    def create(self):
+        create_args = self.generate_create_args()
+        dhcp_options = self.execute(self.client.create_dhcp_options,
+                                    create_args, raise_on_falsy=True)
+        self.resource_id = dhcp_options.id
+        return True
+
+    def generate_create_args(self):
+        return dict(
+            domain_name=ctx.node.properties['domain_name'],
+            domain_name_servers=ctx.node.properties['domain_name_servers'],
+            ntp_servers=ctx.node.properties['ntp_servers'],
+            netbios_name_servers=ctx.node.properties['netbios_name_servers'],
+            netbios_node_type=ctx.node.properties['netbios_node_type']
+        )
+
+    def delete(self):
+        delete_args = dict(dhcp_options_id=self.resource_id)
+        return self.execute(self.client.delete_dhcp_options,
+                            delete_args, raise_on_falsy=True)

--- a/vpc/gateway.py
+++ b/vpc/gateway.py
@@ -1,0 +1,301 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Cloudify imports
+from ec2 import utils as ec2_utils
+from . import constants
+from core.base import AwsBaseNode, AwsBaseRelationship
+from cloudify import ctx
+from cloudify.decorators import operation
+
+
+@operation
+def creation_validation(**_):
+    if 'cloudify.aws.nodes.InternetGateway' in ctx.node.type_hierarchy:
+        return InternetGateway().creation_validation()
+    if 'cloudify.aws.nodes.VPNGateway' in ctx.node.type_hierarchy:
+        return VpnGateway().creation_validation()
+    if 'cloudify.aws.nodes.CustomerGateway' in ctx.node.type_hierarchy:
+        return CustomerGateway().creation_validation()
+
+
+@operation
+def create_internet_gateway(**_):
+    return InternetGateway().created()
+
+
+@operation
+def delete_internet_gateway(**_):
+    return InternetGateway().deleted()
+
+
+@operation
+def create_vpn_gateway(**_):
+    return VpnGateway().created()
+
+
+@operation
+def delete_vpn_gateway(**_):
+    return VpnGateway().deleted()
+
+
+@operation
+def create_customer_gateway(**_):
+    return CustomerGateway().created()
+
+
+@operation
+def delete_customer_gateway(**_):
+    return CustomerGateway().deleted()
+
+
+@operation
+def create_vpn_connection(routes, **_):
+    return VpnConnection(routes).associated()
+
+
+@operation
+def delete_vpn_connection(**_):
+    return VpnConnection().disassociated()
+
+
+@operation
+def attach_gateway(**_):
+    return GatewayVpcAttachment().associated()
+
+
+@operation
+def detach_gateway(**_):
+    return GatewayVpcAttachment().disassociated()
+
+
+class VpnConnection(AwsBaseRelationship):
+
+    def __init__(self, routes=None):
+        super(VpnConnection, self).__init__(routes)
+        self.vpn_type = ctx.source.node.properties['type']
+        self.routes = \
+            routes if routes else \
+            ctx.source.instance.runtime_properties.get('routes', None)
+        self.vpn_connection_id = \
+            ctx.source.instance.runtime_properties.get(
+                'vpn_connection') if \
+            'vpn_connection' in \
+            ctx.source.instance.runtime_properties.keys() else \
+            None
+        self.source_get_all_handler = {
+            'function': self.client.get_all_customer_gateways,
+            'argument':
+            '{0}_ids'.format(constants.CUSTOMER_GATEWAY['AWS_RESOURCE_TYPE'])
+        }
+
+    def associate(self):
+        associate_args = self.generate_associate_args(self.routes)
+        vpn_connection = self.execute(self.client.create_vpn_connection,
+                                      associate_args, raise_on_falsy=True)
+        ctx.source.instance.runtime_properties['vpn_connection'] = \
+            vpn_connection.id
+        ctx.source.instance.runtime_properties['vpn_gateway'] = \
+            vpn_connection.vpn_gateway_id
+        if 'routes' not in ctx.source.instance.runtime_properties.keys():
+            ctx.source.instance.runtime_properties['routes'] = []
+        if self.routes:
+            for route in self.routes:
+                args = self.generate_route_args(vpn_connection.id, route)
+                self.execute(self.client.create_vpn_connection_route,
+                             args, raise_on_falsy=True)
+                ctx.source.instance.runtime_properties['routes'].append(route)
+        return True
+
+    def generate_associate_args(self, routes):
+
+        return dict(
+            type=self.vpn_type,
+            customer_gateway_id=self.source_resource_id,
+            vpn_gateway_id=self.target_resource_id,
+            static_routes_only=False if not routes or not
+            ctx.source.node.properties['bgp_asn'] else True
+        )
+
+    def generate_route_args(self, vpn_connection_id, route):
+        args = dict(
+            destination_cidr_block=route['destination_cidr_block'],
+            vpn_connection_id=vpn_connection_id
+        )
+        return args
+
+    def disassociate(self):
+        if self.routes:
+            for route in self.routes:
+                args = self.generate_route_args(self.vpn_connection_id, route)
+                if self.execute(
+                        self.client.delete_vpn_connection_route,
+                        args, raise_on_falsy=True):
+                    ctx.source.instance.runtime_properties['routes'].remove(
+                        route)
+        disassociate_args = dict(vpn_connection_id=self.vpn_connection_id)
+        return self.execute(self.client.delete_vpn_connection,
+                            disassociate_args, raise_on_falsy=True)
+
+
+class GatewayVpcAttachment(AwsBaseRelationship):
+    def __init__(self, routes=None):
+        super(GatewayVpcAttachment, self).__init__()
+        self.vpn_type = 'ipsec.1'
+        if self.is_vpn_gateway():
+            self.attachment_function = self.client.attach_vpn_gateway
+            self.attachment_args = dict(
+                vpn_gateway_id=self.source_resource_id,
+                vpc_id=self.target_resource_id
+            )
+            self.detachment_function = self.client.detach_vpn_gateway
+            self.detachment_args = dict(
+                vpn_gateway_id=self.source_resource_id,
+                vpc_id=self.target_resource_id
+            )
+            self.source_get_all_handler = {
+                'function': self.client.get_all_vpn_gateways,
+                'argument':
+                '{0}_ids'.format(constants.VPN_GATEWAY['AWS_RESOURCE_TYPE'])
+            }
+        else:
+            self.attachment_function = self.client.attach_internet_gateway
+            self.attachment_args = dict(
+                internet_gateway_id=self.source_resource_id,
+                vpc_id=self.target_resource_id
+            )
+            self.detachment_function = self.client.detach_internet_gateway
+            self.detachment_args = dict(
+                internet_gateway_id=self.source_resource_id,
+                vpc_id=self.target_resource_id
+            )
+            self.source_get_all_handler = {
+                'function': self.client.get_all_internet_gateways,
+                'argument':
+                '{0}_ids'.format(
+                    constants.INTERNET_GATEWAY['AWS_RESOURCE_TYPE'])
+            }
+
+    def associate(self):
+        return self.execute(self.attachment_function,
+                            self.attachment_args, raise_on_falsy=True)
+
+    def disassociate(self):
+        return self.execute(self.detachment_function,
+                            self.detachment_args,
+                            raise_on_falsy=True)
+
+    def is_vpn_gateway(self):
+        if constants.VPN_GATEWAY['CLOUDIFY_NODE_TYPE'] in \
+                ctx.source.node.type_hierarchy \
+                and constants.CUSTOMER_GATEWAY['CLOUDIFY_NODE_TYPE'] \
+                not in ctx.source.node.type_hierarchy:
+            return True
+        return False
+
+    def post_associate(self):
+        ctx.source.instance.runtime_properties['vpc_id'] = \
+            self.target_resource_id
+
+    def post_disassociate(self):
+        ec2_utils.unassign_runtime_property_from_resource(
+            'vpc_id', ctx.source.instance)
+
+
+class InternetGateway(AwsBaseNode):
+
+    def __init__(self):
+        super(InternetGateway, self).__init__(
+            constants.INTERNET_GATEWAY['AWS_RESOURCE_TYPE'],
+            constants.INTERNET_GATEWAY['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.INTERNET_GATEWAY['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_internet_gateways,
+            'argument':
+            '{0}_ids'.format(constants.INTERNET_GATEWAY['AWS_RESOURCE_TYPE'])
+        }
+
+    def create(self):
+        gateway = self.execute(self.client.create_internet_gateway,
+                               raise_on_falsy=True)
+        self.resource_id = gateway.id
+        return True
+
+    def delete(self):
+        delete_args = dict(internet_gateway_id=self.resource_id)
+        return self.execute(self.client.delete_internet_gateway,
+                            delete_args)
+
+
+class VpnGateway(AwsBaseNode):
+
+    def __init__(self):
+        super(VpnGateway, self).__init__(
+            constants.VPN_GATEWAY['AWS_RESOURCE_TYPE'],
+            constants.VPN_GATEWAY['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.VPN_GATEWAY['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_vpn_gateways,
+            'argument':
+            '{0}_ids'.format(constants.VPN_GATEWAY['AWS_RESOURCE_TYPE'])
+        }
+
+    def create(self):
+        create_args = dict(
+            type=ctx.node.properties['type'],
+            availability_zone=ctx.node.properties.get(
+                'availability_zone', None)
+        )
+        gateway = self.execute(self.client.create_vpn_gateway,
+                               create_args, raise_on_falsy=True)
+        self.resource_id = gateway.id
+        return True
+
+    def delete(self):
+        delete_args = dict(vpn_gateway_id=self.resource_id)
+        return self.execute(self.client.delete_vpn_gateway, delete_args)
+
+
+class CustomerGateway(AwsBaseNode):
+
+    def __init__(self):
+        super(CustomerGateway, self).__init__(
+            constants.CUSTOMER_GATEWAY['AWS_RESOURCE_TYPE'],
+            constants.CUSTOMER_GATEWAY['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.CUSTOMER_GATEWAY['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_customer_gateways,
+            'argument':
+            '{0}_ids'.format(constants.CUSTOMER_GATEWAY['AWS_RESOURCE_TYPE'])
+        }
+
+    def create(self):
+        create_args = dict(
+            type=ctx.node.properties['type'],
+            ip_address=ctx.node.properties['ip_address'],
+            bgp_asn=ctx.node.properties['bgp_asn']
+        )
+        gateway = self.execute(self.client.create_customer_gateway,
+                               create_args, raise_on_falsy=True)
+        self.resource_id = gateway.id
+        return True
+
+    def delete(self):
+        delete_args = dict(customer_gateway_id=self.resource_id)
+        return self.execute(self.client.delete_customer_gateway,
+                            delete_args)

--- a/vpc/networkacl.py
+++ b/vpc/networkacl.py
@@ -1,0 +1,152 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Cloudify imports
+from ec2 import utils as ec2_utils
+from . import constants
+from core.base import AwsBaseNode, AwsBaseRelationship
+from cloudify import ctx
+from cloudify.decorators import operation
+from cloudify.exceptions import NonRecoverableError
+
+
+@operation
+def creation_validation(**_):
+    return NetworkAcl().creation_validation()
+
+
+@operation
+def create_network_acl(**_):
+    return NetworkAcl().created()
+
+
+@operation
+def delete_network_acl(**_):
+    return NetworkAcl().deleted()
+
+
+@operation
+def associate_network_acl(**_):
+    return NetworkAclSubnetAssociation().associated()
+
+
+@operation
+def disassociate_network_acl(**_):
+    return NetworkAclSubnetAssociation().disassociated()
+
+
+class NetworkAclSubnetAssociation(AwsBaseRelationship):
+
+    def __init__(self):
+        super(NetworkAclSubnetAssociation, self).__init__()
+        self.association_id = \
+            ctx.source.instance.runtime_properties\
+            .get('association_id', None)\
+            if ctx.source.instance.runtime_properties\
+            .get('association_id', None)\
+            else {}
+        self.source_get_all_handler = {
+            'function': self.client.get_all_network_acls,
+            'argument':
+            '{0}_ids'.format(constants.NETWORK_ACL['AWS_RESOURCE_TYPE'])
+        }
+
+    def associate(self):
+        assoicate_args = dict(
+            network_acl_id=self.source_resource_id,
+            subnet_id=self.target_resource_id
+        )
+        self.association_id = \
+            self.execute(self.client.associate_network_acl,
+                         assoicate_args, raise_on_falsy=True)
+        return True
+
+    def disassociate(self):
+        disassociate_args = dict(
+            subnet_id=self.target_resource_id,
+            vpc_id=ctx.source.instance.runtime_properties['vpc_id']
+        )
+        return self.execute(self.client.disassociate_network_acl,
+                            disassociate_args, raise_on_falsy=True)
+
+    def post_associate(self):
+        ctx.source.instance.runtime_properties['association_id'] = \
+            self.association_id
+
+    def post_disassociate(self):
+        ec2_utils.unassign_runtime_property_from_resource(
+            'association_id', ctx.source.instance)
+
+
+class NetworkAcl(AwsBaseNode):
+
+    def __init__(self):
+        super(NetworkAcl, self).__init__(
+            constants.NETWORK_ACL['AWS_RESOURCE_TYPE'],
+            constants.NETWORK_ACL['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.NETWORK_ACL['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_network_acls,
+            'argument':
+            '{0}_ids'.format(constants.NETWORK_ACL['AWS_RESOURCE_TYPE'])
+        }
+
+    def create(self):
+        create_args = self.generate_create_args()
+        network_acl = self.execute(self.client.create_network_acl,
+                                   create_args, raise_on_falsy=True)
+        self.resource_id = network_acl.id
+        ctx.instance.runtime_properties['vpc_id'] = create_args['vpc_id']
+        self.add_entries_to_network_acl()
+        return True
+
+    def generate_create_args(self):
+        relationships = \
+            self.get_related_targets_and_types(ctx.instance.relationships)
+        vpc_ids = \
+            self.get_target_ids_of_relationship_type(
+                constants.NETWORK_ACL_IN_VPC_RELATIONSHIP, relationships)
+        if not len(vpc_ids) == 1:
+            raise NonRecoverableError(
+                'network acl can only be connected to one vpc')
+        vpc = \
+            self.filter_for_single_resource(
+                self.client.get_all_vpcs,
+                {'vpc_ids': vpc_ids[0]},
+                constants.VPC['NOT_FOUND_ERROR']
+            )
+        create_args = dict(vpc_id=vpc.id)
+        return create_args
+
+    def add_entries_to_network_acl(self):
+
+        ctx.logger.info(
+            'adding network acl entries to network acl {0}'
+            .format(self.resource_id))
+
+        for acl_network_entry in ctx.node.properties['acl_network_entries']:
+            acl_network_entry['network_acl_id'] = self.resource_id
+            self.create_network_acl_entry(acl_network_entry)
+
+    def create_network_acl_entry(self, args):
+        ctx.logger.info('create network acl entry {0}'.format(args))
+        return self.execute(self.client.create_network_acl_entry,
+                            args, raise_on_falsy=True)
+
+    def delete(self):
+        delete_args = dict(network_acl_id=self.resource_id)
+        return self.execute(self.client.delete_network_acl,
+                            delete_args, raise_on_falsy=True)

--- a/vpc/routetable.py
+++ b/vpc/routetable.py
@@ -1,0 +1,210 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Cloudify imports
+from . import constants
+from core.base import AwsBaseNode, AwsBaseRelationship, RouteMixin
+from cloudify import ctx
+from cloudify.decorators import operation
+from cloudify.exceptions import NonRecoverableError
+from ec2 import utils as ec2_utils
+
+
+@operation
+def creation_validation(**_):
+    return RouteTable().creation_validation()
+
+
+@operation
+def create_route_table(routes, **_):
+    return RouteTable(routes).created()
+
+
+@operation
+def delete_route_table(**_):
+    return RouteTable().deleted()
+
+
+@operation
+def associate_route_table(**_):
+    return RouteTableSubnetAssociation().associated()
+
+
+@operation
+def disassociate_route_table(**_):
+    return RouteTableSubnetAssociation().disassociated()
+
+
+@operation
+def create_route_to_gateway(**_):
+    return RouteTableGatewayAssociation().associated()
+
+
+@operation
+def delete_route_from_gateway(**_):
+    return RouteTableGatewayAssociation().disassociated()
+
+
+class RouteTableGatewayAssociation(AwsBaseRelationship, RouteMixin):
+
+    def __init__(self):
+        super(RouteTableGatewayAssociation, self).__init__()
+        self.source_get_all_handler = {
+            'function': self.client.get_all_route_tables,
+            'argument':
+            '{0}_ids'.format(constants.ROUTE_TABLE['AWS_RESOURCE_TYPE'])
+        }
+
+    def associate(self):
+
+        route = dict(
+            destination_cidr_block=ctx.target.node.properties['cidr_block'],
+            gateway_id=ctx.target.instance.runtime_properties[
+                constants.EXTERNAL_RESOURCE_ID]
+        )
+
+        return self.create_route(
+            ctx.source.instance.runtime_properties[
+                constants.EXTERNAL_RESOURCE_ID],
+            route, ctx.source.instance
+        )
+
+    def disassociate(self):
+        route = dict(
+            destination_cidr_block=ctx.target.node.properties['cidr_block'],
+            gateway_id=ctx.target.instance.runtime_properties[
+                constants.EXTERNAL_RESOURCE_ID]
+        )
+        return self.delete_route(
+            ctx.source.instance.runtime_properties.get(
+                constants.EXTERNAL_RESOURCE_ID),
+            route,
+            route_table_ctx_instance=ctx.source.instance
+        )
+
+
+class RouteTableSubnetAssociation(AwsBaseRelationship):
+    def __init__(self):
+        super(RouteTableSubnetAssociation, self).__init__()
+        self.association_id = \
+            ctx.source.instance.runtime_properties.get(
+                'association_id', None)
+        self.source_get_all_handler = {
+            'function': self.client.get_all_route_tables,
+            'argument':
+            '{0}_ids'.format(constants.ROUTE_TABLE['AWS_RESOURCE_TYPE'])
+        }
+
+    def associate(self):
+        associate_args = dict(
+            route_table_id=self.source_resource_id,
+            subnet_id=self.target_resource_id
+        )
+        self.association_id = \
+            self.execute(self.client.associate_route_table,
+                         associate_args, raise_on_falsy=True)
+        return True
+
+    def disassociate(self):
+        disassociate_args = dict(association_id=self.association_id)
+        return self.execute(self.client.disassociate_route_table,
+                            disassociate_args, raise_on_falsy=True)
+
+    def post_associate(self):
+        ctx.source.instance.runtime_properties['association_id'] = \
+            self.association_id
+        ctx.source.instance.runtime_properties['subnet_id'] = \
+            self.target_resource_id
+        return True
+
+    def post_disassociate(self):
+        ctx.source.instance.runtime_properties.pop('association_id')
+        ctx.source.instance.runtime_properties.pop('subnet_id')
+        return True
+
+
+class RouteTable(AwsBaseNode, RouteMixin):
+
+    def __init__(self, routes=None):
+        super(RouteTable, self).__init__(
+            constants.ROUTE_TABLE['AWS_RESOURCE_TYPE'],
+            constants.ROUTE_TABLE['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.ROUTE_TABLE['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_route_tables,
+            'argument':
+            '{0}_ids'.format(constants.ROUTE_TABLE['AWS_RESOURCE_TYPE'])
+        }
+        self.routes = \
+            ctx.instance.runtime_properties.get('routes') \
+            if 'routes' \
+            in ctx.instance.runtime_properties.keys() else routes
+
+    def create(self):
+        create_args = self._generate_creation_args()
+        route_table = \
+            self.execute(self.client.create_route_table,
+                         create_args, raise_on_falsy=True)
+        self.resource_id = route_table.id
+        for route in self.routes:
+            self.create_route(route_table.id, route, ctx.instance)
+        return True
+
+    def _generate_creation_args(self):
+        vpc = self.get_containing_vpc()
+        return dict(vpc_id=vpc.id)
+
+    def get_containing_vpc(self):
+        relationships = \
+            self.get_related_targets_and_types(ctx.instance.relationships)
+        vpc_ids = \
+            self.get_target_ids_of_relationship_type(
+                constants.ROUTE_TABLE_VPC_RELATIONSHIP, relationships)
+        if not len(vpc_ids) == 1:
+            raise NonRecoverableError(
+                'routetable can only be connected to one vpc')
+        vpc = self.filter_for_single_resource(
+            self.client.get_all_vpcs,
+            {'vpc_ids': vpc_ids[0]},
+            constants.VPC['NOT_FOUND_ERROR']
+        )
+        return vpc
+
+    def post_create(self):
+        vpc = self.get_containing_vpc()
+        ctx.instance.runtime_properties['vpc_id'] = vpc.id
+        ctx.instance.runtime_properties['routes'] = self.routes
+        ec2_utils.set_external_resource_id(self.resource_id, ctx.instance)
+        ctx.logger.info(
+            'Added {0} {1} to Cloudify.'
+            .format(self.aws_resource_type, self.resource_id))
+        return True
+
+    def delete(self):
+        for route in self.routes:
+            self.delete_route(
+                ctx.instance.runtime_properties.get(
+                    constants.EXTERNAL_RESOURCE_ID),
+                route,
+                route_table_ctx_instance=ctx.instance
+            )
+        delete_args = dict(
+            route_table_id=ctx.instance.runtime_properties.get(
+                constants.EXTERNAL_RESOURCE_ID
+            )
+        )
+        return self.execute(self.client.delete_route_table,
+                            delete_args, raise_on_falsy=True)

--- a/vpc/subnet.py
+++ b/vpc/subnet.py
@@ -1,0 +1,95 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Cloudify imports
+from . import constants
+from core.base import AwsBaseNode
+from cloudify import ctx
+from cloudify.decorators import operation
+from cloudify.exceptions import NonRecoverableError
+
+
+@operation
+def creation_validation(**_):
+    return Subnet().creation_validation()
+
+
+@operation
+def create_subnet(**_):
+    return Subnet().created()
+
+
+@operation
+def delete_subnet(**_):
+    return Subnet().deleted()
+
+
+class Subnet(AwsBaseNode):
+
+    def __init__(self):
+        super(Subnet, self).__init__(
+            constants.SUBNET['AWS_RESOURCE_TYPE'],
+            constants.SUBNET['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.SUBNET['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_subnets,
+            'argument': '{0}_ids'.format(constants.SUBNET['AWS_RESOURCE_TYPE'])
+        }
+
+    def create(self):
+        create_args = self._generate_creation_args()
+        subnet = self.execute(self.client.create_subnet,
+                              create_args, raise_on_falsy=True)
+        self.resource_id = subnet.id
+        return True
+
+    def _generate_creation_args(self):
+
+        relationships = \
+            self.get_related_targets_and_types(ctx.instance.relationships)
+
+        vpc_ids = self.get_target_ids_of_relationship_type(
+            constants.SUBNET_IN_VPC, relationships)
+
+        if not len(vpc_ids) == 1:
+            raise NonRecoverableError(
+                'subnet can only be connected to one vpc')
+
+        vpc = self.filter_for_single_resource(
+            self.client.get_all_vpcs,
+            {'vpc_ids': vpc_ids[0]},
+            constants.VPC['NOT_FOUND_ERROR']
+        )
+
+        create_args = dict(
+            vpc_id=vpc.id,
+            cidr_block=ctx.node.properties['cidr_block']
+        )
+
+        if ctx.node.properties[constants.AVAILABILITY_ZONE]:
+            create_args.update(
+                {
+                    constants.AVAILABILITY_ZONE:
+                    ctx.node.properties[constants.AVAILABILITY_ZONE]
+                }
+            )
+
+        return create_args
+
+    def delete(self):
+        delete_args = dict(subnet_id=self.resource_id)
+        return self.execute(self.client.delete_subnet,
+                            delete_args, raise_on_falsy=True)

--- a/vpc/tests/__init__.py
+++ b/vpc/tests/__init__.py
@@ -12,32 +12,3 @@
 #    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
-
-
-from setuptools import setup
-
-# Replace the place holders with values for your project
-
-setup(
-
-    # Do not use underscores in the plugin name.
-    name='cloudify-aws-plugin',
-    author='Gigaspaces',
-    author_email='cosmo-admin@gigaspaces.com',
-
-    version='1.3',
-    description='Cloudify plugin for AWS infrastructure.',
-
-    # This must correspond to the actual packages in the plugin.
-    packages=[
-        'core',
-        'ec2',
-        'vpc'
-    ],
-
-    license='LICENSE',
-    install_requires=[
-        'cloudify-plugins-common>=3.3',
-        'boto==2.38.0'
-    ]
-)

--- a/vpc/tests/blueprint/blueprint.yaml
+++ b/vpc/tests/blueprint/blueprint.yaml
@@ -1,0 +1,257 @@
+# DSL version, should appear in the main blueprint.yaml
+# and may appear in other imports. In such case, the versions must match
+tosca_definitions_version: cloudify_dsl_1_2
+
+imports:
+  - types.yaml
+  - plugin.yaml
+
+dsl_definitions:
+
+  aws_config: &AWS_CONFIG
+    ec2_region_name: us-east-1
+    ec2_region_endpoint: ec2.us-east-1.amazonaws.com
+
+inputs:
+
+  existing_vpc_id:
+    type: string
+
+  existing_subnet_id:
+    type: string
+
+  existing_internet_gateway_id:
+    type: string
+
+  existing_vpn_gateway_id:
+    type: string
+
+  existing_network_acl_id:
+    type: string
+
+  existing_dhcp_options_id:
+    type: string
+
+  existing_customer_gateway_id:
+    type: string
+
+  existing_route_table_id:
+    type: string
+
+node_templates:
+
+  new_vpc:
+    type: cloudify.aws.nodes.VPC
+    properties:
+      aws_config: *AWS_CONFIG
+      cidr_block: 10.0.0.0/24
+
+  existing_vpc:
+    type: cloudify.aws.nodes.VPC
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_vpc_id }
+      cidr_block: 11.0.0.0/24
+
+  new_subnet:
+    type: cloudify.aws.nodes.Subnet
+    properties:
+      aws_config: *AWS_CONFIG
+      cidr_block: 10.0.0.0/25
+    relationships:
+      - type: cloudify.aws.relationships.subnet_contained_in_vpc
+        target: new_vpc
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: aws.vpc.subnet.create_subnet
+
+  existing_subnet:
+    type: cloudify.aws.nodes.Subnet
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_subnet_id }
+      cidr_block: 11.0.0.0/25
+    relationships:
+      - type: cloudify.aws.relationships.subnet_contained_in_vpc
+        target: existing_vpc
+
+  new_internet_gateway:
+    type: cloudify.aws.nodes.InternetGateway
+    properties:
+      aws_config: *AWS_CONFIG
+    relationships:
+      - type: cloudify.aws.relationships.gateway_connected_to_vpc
+        target: new_vpc
+
+  existing_internet_gateway:
+    type: cloudify.aws.nodes.InternetGateway
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_internet_gateway_id }
+    relationships:
+      - type: cloudify.aws.relationships.gateway_connected_to_vpc
+        target: existing_vpc
+
+  new_vpn_gateway:
+    type: cloudify.aws.nodes.VPNGateway
+    properties:
+      aws_config: *AWS_CONFIG
+    relationships:
+      - type: cloudify.aws.relationships.gateway_connected_to_vpc
+        target: new_vpc
+
+  existing_vpn_gateway:
+    type: cloudify.aws.nodes.VPNGateway
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_vpn_gateway_id }
+    relationships:
+      - type: cloudify.aws.relationships.gateway_connected_to_vpc
+        target: existing_vpc
+
+  new_customer_gateway:
+    type: cloudify.aws.nodes.CustomerGateway
+    properties:
+      aws_config: *AWS_CONFIG
+      ip_address: 10.0.0.7
+      bgp_asn: 65534
+    relationships:
+      - type: cloudify.aws.relationships.customer_gateway_connected_to_vpn_gateway
+        target: new_vpn_gateway
+
+  existing_customer_gateway:
+    type: cloudify.aws.nodes.CustomerGateway
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_customer_gateway_id }
+      ip_address: 11.0.0.7
+      bgp_asn: 65000
+    relationships:
+      - type: cloudify.aws.relationships.customer_gateway_connected_to_vpn_gateway
+        target: existing_vpn_gateway
+
+  new_access_control_list:
+    type: cloudify.aws.nodes.ACL
+    properties:
+      aws_config: *AWS_CONFIG
+      acl_network_entries:
+        - rule_number: 1
+          protocol: tcp
+          rule_action: ALLOW
+          cidr_block: 10.0.0.0/25
+          egress: ''
+          icmp_code: ''
+          icmp_type: ''
+          port_range_from: 80
+          port_range_to: 80
+    relationships:
+      - type: cloudify.aws.relationships.network_acl_contained_in_vpc
+        target: new_vpc
+      - type: cloudify.aws.relationships.network_acl_associated_with_subnet
+        target: new_subnet
+
+  existing_access_control_list:
+    type: cloudify.aws.nodes.ACL
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_network_acl_id }
+      aws_config: *AWS_CONFIG
+      acl_network_entries:
+        - rule_number: 1
+          protocol: tcp
+          rule_action: ALLOW
+          cidr_block: 11.0.0.0/25
+          egress: ''
+          icmp_code: ''
+          icmp_type: ''
+          port_range_from: 80
+          port_range_to: 80
+    relationships:
+      - type: cloudify.aws.relationships.network_acl_contained_in_vpc
+        target: existing_vpc
+      - type: cloudify.aws.relationships.network_acl_associated_with_subnet
+        target: existing_subnet
+
+  new_dhcp_options:
+    type: cloudify.aws.nodes.DHCPOptions
+    properties:
+      aws_config: *AWS_CONFIG
+      domain_name: example.com
+      domain_name_servers:
+        - 0.asia.pool.ntp.org
+        - 1.asia.pool.ntp.org
+        - 2.asia.pool.ntp.org
+        - 3.asia.pool.ntp.org
+    relationships:
+      - type: cloudify.aws.relationships.dhcp_options_associated_with_vpc
+        target: new_vpc
+
+  existing_dhcp_options:
+    type: cloudify.aws.nodes.DHCPOptions
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_dhcp_options_id }
+      netbios_name_servers:
+        - WAT
+        - ISNETBIOS
+      netbios_node_type: 2
+    relationships:
+      - type: cloudify.aws.relationships.dhcp_options_associated_with_vpc
+        target: existing_vpc
+
+  new_route_table:
+    type: cloudify.aws.nodes.RouteTable
+    properties:
+      aws_config: *AWS_CONFIG
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: aws.vpc.routetable.create_route_table
+          inputs:
+            routes:
+              - destination_cidr_block: { get_property: [ new_subnet, cidr_block ] }
+                gateway_id: { get_attribute: [ new_internet_gateway, aws_resource_id ] }
+    relationships:
+      - type: cloudify.aws.relationships.routetable_contained_in_vpc
+        target: new_vpc
+      - type: cloudify.aws.relationships.routetable_associated_with_subnet
+        target: new_subnet
+      - type: cloudify.aws.relationships.route_table_to_gateway
+        target: new_internet_gateway
+      - type: cloudify.aws.relationships.route_table_of_source_vpc_connected_to_target_peer_vpc
+        target: existing_vpc
+        target_interfaces:
+          cloudify.interfaces.relationship_lifecycle:
+            preconfigure:
+              implementation: aws.vpc.vpc.create_vpc_peering_connection
+              inputs:
+                target_account_id: '234567890123'
+                routes:
+                    - destination_cidr_block: { get_property: [ existing_vpc, cidr_block ] }
+
+  existing_route_table:
+    type: cloudify.aws.nodes.RouteTable
+    properties:
+      aws_config: *AWS_CONFIG
+      use_external_resource: true
+      resource_id: { get_input: existing_route_table_id }
+    relationships:
+      - type: cloudify.aws.relationships.routetable_contained_in_vpc
+        target: existing_vpc
+      - type: cloudify.aws.relationships.routetable_associated_with_subnet
+        target: existing_subnet
+      - type: cloudify.aws.relationships.route_table_to_gateway
+        target: existing_internet_gateway
+
+plugins:
+    ec2:
+        executor: central_deployment_agent
+        install: false

--- a/vpc/tests/blueprint/plugin.yaml
+++ b/vpc/tests/blueprint/plugin.yaml
@@ -68,7 +68,6 @@ data_types:
         type: string
         required: false
 
-
   cloudify.datatypes.aws.NetworkAclEntry:
     properties:
       rule_number:

--- a/vpc/tests/blueprint/types.yaml
+++ b/vpc/tests/blueprint/types.yaml
@@ -1,0 +1,571 @@
+##################################################################################
+# The types defined here make use of features only available in the
+# 'cloudify_dsl_1_2' tosca definitions version
+##################################################################################
+tosca_definitions_version: cloudify_dsl_1_2
+
+##################################################################################
+# Base type definitions
+##################################################################################
+node_types:
+
+  # base type for provided cloudify types
+  cloudify.nodes.Root:
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create: {}
+        configure: {}
+        start: {}
+        stop: {}
+        delete: {}
+      cloudify.interfaces.validation:
+        creation: {}
+        deletion: {}
+      cloudify.interfaces.monitoring:
+        start: {}
+        stop: {}
+
+  # A host (physical / virtual or LXC) in a topology
+  cloudify.nodes.Compute:
+    derived_from: cloudify.nodes.Root
+    properties:
+      ip:
+        default: ''
+      os_family:
+        description: |
+          Property specifying what type of operating system family
+          this compute node will run.
+        default: linux
+      agent_config:
+        type: cloudify.datatypes.AgentConfig
+        default:
+          install_method: remote
+          port: 22
+
+      # DEPRECATED
+      install_agent:
+        default: ''
+      cloudify_agent:
+        default: {}
+
+    interfaces:
+      cloudify.interfaces.cloudify_agent:
+
+        #####################################################
+        # This operation will download the necessary files
+        # for the agent and place them were needed.
+        # ---------------------------------------------------
+        # It will be executed on the manager and will connect
+        # to the agent via fabric/winrm
+        #####################################################
+
+        create:
+          implementation: agent.cloudify_agent.installer.operations.create
+          executor: central_deployment_agent
+
+        #####################################################
+        # This operation will create all the necessary
+        # configuration for the agent to be started.
+        # ---------------------------------------------------
+        # It will be executed on the manager and will connect
+        # to the agent via fabric/winrm
+        #####################################################
+
+        configure:
+          implementation: agent.cloudify_agent.installer.operations.configure
+          executor: central_deployment_agent
+
+        #####################################################
+        # This operation will actually start the agent
+        # process.
+        # ---------------------------------------------------
+        # It will be executed on the manager and will connect
+        # to the agent via fabric/winrm
+        #####################################################
+
+        start:
+          implementation: agent.cloudify_agent.installer.operations.start
+          executor: central_deployment_agent
+
+        #####################################################
+        # This operation will stop the agent process.
+        # ---------------------------------------------------
+        # It will be executed on the manager and will connect
+        # to the agent via fabric/winrm
+        #####################################################
+
+        stop:
+          implementation: agent.cloudify_agent.installer.operations.stop
+          executor: central_deployment_agent
+
+        #####################################################
+        # This operation will stop the agent process
+        # whithout connecting to the remote host.
+        # ---------------------------------------------------
+        # It will be executed on the agent host via AMQP
+        #####################################################
+
+        stop_amqp:
+          implementation: agent.cloudify_agent.operations.stop
+          executor: host_agent
+
+        #####################################################
+        # This operation will delete agent resources.
+        # ---------------------------------------------------
+        # It will be executed on the manager and will connect
+        # to the agent via fabric/winrm
+        #####################################################
+
+        delete:
+          implementation: agent.cloudify_agent.installer.operations.delete
+          executor: central_deployment_agent
+
+        #####################################################
+        # This operation will restart the agent process.
+        # ---------------------------------------------------
+        # It will be executed on the manager and will connect
+        # to the agent via fabric/winrm
+        #####################################################
+
+        restart:
+          implementation: agent.cloudify_agent.installer.operations.restart
+          executor: central_deployment_agent
+
+        #####################################################
+        # This operation will restart the agent process
+        # whithout connecting to the remote host.
+        # the agent will have a new name after this
+        # operation, but will of course listen to the same
+        # queue.
+        # ---------------------------------------------------
+        # It will be executed on the agent host via AMQP
+        #####################################################
+
+        restart_amqp:
+          implementation: agent.cloudify_agent.operations.restart
+          executor: host_agent
+
+        #####################################################
+        # This operation will install additional plugins
+        # on the agent environment.
+        # ---------------------------------------------------
+        # It will be executed directly on the agent via AMQP.
+        # not requiring any new remote connection to be
+        # established.
+        #####################################################
+
+        install_plugins:
+          implementation: agent.cloudify_agent.operations.install_plugins
+          executor: host_agent
+
+
+        #####################################################
+        # This operation will install new agent on specific
+        # machine using existing agent.
+        # ---------------------------------------------------
+        # It will be executed on central deployment agent.
+        # This agent will send installation request via AMQP
+        # to an agent that was previously installed.
+        # This request might be sent to other manager's
+        # rabbitmq server.
+        #####################################################
+
+        create_amqp:
+          implementation: agent.cloudify_agent.operations.create_agent_amqp
+          executor: central_deployment_agent
+          inputs:
+            install_agent_timeout:
+              default: 300
+
+
+      cloudify.interfaces.host:  # DEPRECATED
+        get_state: {}
+
+      cloudify.interfaces.monitoring_agent:
+        install: {}
+        start: {}
+        stop: {}
+        uninstall: {}
+
+  # A Linux container with or without docker
+  cloudify.nodes.Container:
+    derived_from: cloudify.nodes.Compute
+
+  # A tier in a topology
+  cloudify.nodes.Tier:
+    derived_from: cloudify.nodes.Root
+
+  # A storage volume in a topology
+  cloudify.nodes.Volume:
+    derived_from: cloudify.nodes.Root
+
+  # A file system a volume should be formatted to
+  cloudify.nodes.FileSystem:
+    derived_from: cloudify.nodes.Root
+    properties:
+      use_external_resource:
+        description: >
+          Enables the use of already formatted volumes.
+        type: boolean
+        default: false
+      partition_type:
+        description: >
+          The partition type. 83 is a Linux Native Partition.
+        type: integer
+        default: 83
+      fs_type:
+        description: >
+          The type of the File System.
+          Supported types are [ext2, ext3, ext4, fat, ntfs, swap]
+        type: string
+      fs_mount_path:
+        description: >
+          The path of the mount point.
+        type: string
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        configure:
+          implementation: script.script_runner.tasks.run
+          inputs:
+            script_path:
+              default: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/fs/mkfs.sh
+
+  # A storage Container (Object Store segment)
+  cloudify.nodes.ObjectStorage:
+    derived_from: cloudify.nodes.Root
+
+  # An isolated virtual layer 2 domain or a logical / virtual switch
+  cloudify.nodes.Network:
+    derived_from: cloudify.nodes.Root
+
+  # An isolated virtual layer 3 subnet with IP range
+  cloudify.nodes.Subnet:
+    derived_from: cloudify.nodes.Root
+
+  cloudify.nodes.Port:
+    derived_from: cloudify.nodes.Root
+
+  # A network router
+  cloudify.nodes.Router:
+    derived_from: cloudify.nodes.Root
+
+  # A virtual Load Balancer
+  cloudify.nodes.LoadBalancer:
+    derived_from: cloudify.nodes.Root
+
+  # A virtual floating IP
+  cloudify.nodes.VirtualIP:
+    derived_from: cloudify.nodes.Root
+
+  # A security group
+  cloudify.nodes.SecurityGroup:
+    derived_from: cloudify.nodes.Root
+
+  # A middleware component in a topology
+  cloudify.nodes.SoftwareComponent:
+    derived_from: cloudify.nodes.Root
+
+  cloudify.nodes.DBMS:
+    derived_from: cloudify.nodes.SoftwareComponent
+
+  cloudify.nodes.Database:
+    derived_from: cloudify.nodes.Root
+
+  cloudify.nodes.WebServer:
+    derived_from: cloudify.nodes.SoftwareComponent
+    properties:
+      port:
+        default: 80
+
+  cloudify.nodes.ApplicationServer:
+    derived_from: cloudify.nodes.SoftwareComponent
+
+  cloudify.nodes.MessageBusServer:
+    derived_from: cloudify.nodes.SoftwareComponent
+
+  # An application artifact to deploy
+  cloudify.nodes.ApplicationModule:
+    derived_from: cloudify.nodes.Root
+
+  # A type for a Cloudify Manager, to be used in manager blueprints
+  cloudify.nodes.CloudifyManager:
+    derived_from: cloudify.nodes.SoftwareComponent
+    properties:
+      cloudify:
+        description: >
+          Configuration for Cloudify Manager
+        default:
+          transient_deployment_workers_mode:
+            enabled: true
+            global_parallel_executions_limit: 50  # -1 means no limit
+          resources_prefix: ''
+          cloudify_agent:
+            min_workers: 2
+            max_workers: 5
+            remote_execution_port: 22
+            user: ubuntu
+          workflows:
+            task_retries: -1  # this means forever
+            task_retry_interval: 30
+          policy_engine:
+            start_timeout: 30
+      cloudify_packages:
+        description: >
+          Links to Cloudify packages to be installed on the manager
+
+##################################################################################
+# Base relationship definitions
+##################################################################################
+relationships:
+
+  cloudify.relationships.depends_on:
+    source_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        preconfigure: {}
+        postconfigure: {}
+        establish: {}
+        unlink: {}
+    target_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        preconfigure: {}
+        postconfigure: {}
+        establish: {}
+        unlink: {}
+    properties:
+      connection_type:
+        default: all_to_all
+
+  cloudify.relationships.connected_to:
+    derived_from: cloudify.relationships.depends_on
+
+  cloudify.relationships.contained_in:
+    derived_from: cloudify.relationships.depends_on
+
+  cloudify.relationships.file_system_depends_on_volume:
+    derived_from: cloudify.relationships.depends_on
+    source_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        preconfigure:
+          implementation: script.script_runner.tasks.run
+          inputs:
+            script_path:
+              default: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/fs/fdisk.sh
+            device_name:
+              default: { get_attribute: [TARGET, device_name] }
+
+  cloudify.relationships.file_system_contained_in_compute:
+    derived_from: cloudify.relationships.contained_in
+    source_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        establish:
+          implementation: script.script_runner.tasks.run
+          inputs:
+            script_path:
+              default: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/fs/mount.sh
+        unlink:
+          implementation: script.script_runner.tasks.run
+          inputs:
+            script_path:
+              default: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/fs/unmount.sh
+
+##################################################################################
+# Workflows
+##################################################################################
+workflows:
+
+  install: default_workflows.cloudify.plugins.workflows.install
+
+  uninstall: default_workflows.cloudify.plugins.workflows.uninstall
+
+  execute_operation:
+    mapping: default_workflows.cloudify.plugins.workflows.execute_operation
+    parameters:
+      operation: {}
+      operation_kwargs:
+        default: {}
+      allow_kwargs_override:
+        default: null
+      run_by_dependency_order:
+        default: false
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
+  heal:
+    mapping: default_workflows.cloudify.plugins.workflows.auto_heal_reinstall_node_subgraph
+    parameters:
+      node_instance_id:
+        description: Which node instance has failed
+      diagnose_value:
+        description: Diagnosed reason of failure
+        default: Not provided
+
+  scale:
+    mapping: default_workflows.cloudify.plugins.workflows.scale
+    parameters:
+      node_id:
+        description: Which node (not node instance) to scale
+      delta:
+        description: >
+            How many nodes should be added/removed.
+            A positive number denotes increase of instances.
+            A negative number denotes decrease of instances.
+        default: 1
+      scale_compute:
+        description: >
+            If node is contained (transitively) within a compute node
+            and this property is 'true', operate on compute node instead
+            of 'node_id'
+        default: true
+
+  install_new_agents:
+    mapping: default_workflows.cloudify.plugins.workflows.install_new_agents
+    parameters:
+      install_agent_timeout:
+        default: 300
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
+##################################################################################
+# Base data type definitions
+##################################################################################
+data_types:
+
+  cloudify.datatypes.AgentConfig:
+    properties:
+      install_method:
+        type: string
+        required: true
+      user:
+        type: string
+        required: false
+      key:
+        type: string
+        required: false
+      password:
+        type: string
+        required: false
+      port:
+        type: integer
+        required: false
+      process_management:
+        required: false
+      min_workers:
+        type: integer
+        required: false
+      max_workers:
+        type: integer
+        required: false
+      disable_requiretty:
+        type: boolean
+        required: false
+      env:
+        required: false
+      extra:
+        required: false
+
+##################################################################################
+# Base artifact definitions
+##################################################################################
+plugins:
+
+  agent:
+    executor: central_deployment_agent
+    install: false
+
+  default_workflows:
+    executor: central_deployment_agent
+    install: false
+
+  script:
+    executor: host_agent
+    install: false
+
+##################################################################################
+# Policy types definitions
+##################################################################################
+policy_types:
+
+    cloudify.policies.types.host_failure:
+        properties: &BASIC_AH_POLICY_PROPERTIES
+            policy_operates_on_group:
+                description: |
+                    If the policy should maintain its state for the whole group
+                    or each node instance individually.
+                default: false
+            is_node_started_before_workflow:
+                description: Before triggering workflow, check if the node state is started
+                default: true
+            interval_between_workflows:
+                description: |
+                    Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.
+                    if < 0  workflows can run concurrently.
+                default: 300
+            service:
+                description: Service names whose events should be taken into consideration
+                default:
+                    - service
+        source: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/policies/host_failure.clj
+
+    cloudify.policies.types.threshold:
+        properties: &THRESHOLD_BASED_POLICY_PROPERTIES
+            <<: *BASIC_AH_POLICY_PROPERTIES
+            service:
+                description: The service name
+                default: service
+            threshold:
+                description: The metric threshold value
+            upper_bound:
+                description: |
+                    boolean value for describing the semantics of the threshold.
+                    if 'true': metrics whose value is bigger than the threshold will cause the triggers to be processed.
+                    if 'false': metrics with values lower than the threshold will do so.
+                default: true
+            stability_time:
+                description: How long a threshold must be breached before the triggers will be processed
+                default: 0
+        source: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/policies/threshold.clj
+
+    cloudify.policies.types.ewma_stabilized:
+        properties:
+            <<: *THRESHOLD_BASED_POLICY_PROPERTIES
+            ewma_timeless_r:
+                description: |
+                    r is the ratio between successive events. The smaller it is, the smaller impact on the computed value the most recent event has.
+                default: 0.5
+        source: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/policies/ewma_stabilized.clj
+
+##################################################################################
+# Policy triggers definitions
+##################################################################################
+policy_triggers:
+
+  cloudify.policies.triggers.execute_workflow:
+    parameters:
+      workflow:
+        description: Workflow name to execute
+      workflow_parameters:
+        description: Workflow paramters
+        default: {}
+      force:
+        description: |
+          Should the workflow be executed even when another execution
+          for the same workflow is currently in progress
+        default: false
+      allow_custom_parameters:
+        description: |
+          Should parameters not defined in the workflow parameters
+          schema be accepted
+        default: false
+      socket_timeout:
+        description: Socket timeout when making request to manager REST in ms
+        default: 1000
+      conn_timeout:
+        description: Connection timeout when making request to manager REST in ms
+        default: 1000
+    source: https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/3.3/resources/rest-service/cloudify/triggers/execute_workflow.clj

--- a/vpc/tests/test_vpc_unittests.py
+++ b/vpc/tests/test_vpc_unittests.py
@@ -1,0 +1,228 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Built-in Imports
+# import re
+import mock
+
+# Third-party Imports
+from moto import mock_ec2
+
+# Cloudify Imports
+from vpc.vpc import (
+    delete
+)
+from vpc.subnet import (
+    create_subnet,
+    delete_subnet
+)
+from vpc.routetable import (
+    delete_route_table
+)
+from vpc.dhcp import (
+    delete_dhcp_options
+)
+from vpc_testcase import VpcTestCase
+from cloudify.state import current_ctx
+from cloudify.exceptions import NonRecoverableError
+from vpc import constants
+
+# VPC_ID_FORMAT = '^vpc\-[0-9a-z]{8}$'
+# SUBNET_ID_FORMAT = '^subnet\-[0-9a-z]{8}$'
+# IG_FORMAT = '^igw\-[0-9a-z]{8}$'
+# VPN_GATEWAY_FORMAT = '^vgw\-[0-9a-z]{8}$'
+# ACL_FORMAT = '^acl\-[0-9a-z]{8}$'
+# DHCP_FORMAT = '^dopt\-[0-9a-z]{8}$'
+# CUSTOMER_GATEWAY_FORMAT = '^cgw\-[0-9a-z]{8}$'
+# ROUTE_TABLE_FORMAT = '^rtb\-[0-9a-z]{8}$'
+#
+VPC_TYPE = 'cloudify.aws.nodes.VPC'
+SUBNET_TYPE = 'cloudify.aws.nodes.Subnet'
+# INTERNET_GATEWAY_TYPE = 'cloudify.aws.nodes.InternetGateway'
+# VPN_GATEWAY_TYPE = 'cloudify.aws.nodes.VPNGateway'
+# CUSTOMER_GATEWAY_TYPE = 'cloudify.aws.nodes.CustomerGateway'
+# ACL_TYPE = 'cloudify.aws.nodes.ACL'
+DHCP_OPTIONS_TYPE = 'cloudify.aws.nodes.DHCPOptions'
+ROUTE_TABLE_TYPE = 'cloudify.aws.nodes.RouteTable'
+
+
+class TestVpcModule(VpcTestCase):
+
+    def get_mock_vpc_node_instance_context(self, test_name):
+
+        inputs = dict()
+
+        node_context = self.mock_node_context(
+            test_name,
+            self.get_mock_node_properties(
+                self.vpc_node_template_properties(inputs)
+            )
+        )
+
+        node_context.node.type = VPC_TYPE
+        node_context.node.type_hierarchy = \
+            [node_context.node.type, 'cloudify.nodes.Root']
+
+        current_ctx.set(ctx=node_context)
+
+        return node_context
+
+    @mock_ec2
+    def test_delete_invalid_vpc_id(self):
+        ctx = self.get_mock_vpc_node_instance_context(
+            'test_delete_invalid_vpc_id')
+        ctx.instance.runtime_properties['aws_resource_id'] = 'vpc-0123abcd'
+        error = self.assertRaises(NonRecoverableError, delete, ctx=ctx)
+        self.assertIn(
+            'Cannot use_external_resource because resource '
+            'vpc-0123abcd is not in this account',
+            error.message)
+
+
+class TestSubnetModule(VpcTestCase):
+
+    class Vpc(object):
+        def __init__(self):
+            self.id = 'vpc-0123abcd'
+
+    def get_mock_subnet_node_instance_context(self, test_name, inputs=None):
+
+        inputs = dict() if not inputs else inputs
+
+        node_context = self.mock_node_context(
+            test_name,
+            self.get_mock_node_properties(
+                self.subnet_node_template_properties(inputs)
+            )
+        )
+
+        node_context.node.type = SUBNET_TYPE
+        node_context.node.type_hierarchy = \
+            [node_context.node.type, 'cloudify.nodes.Root']
+
+        current_ctx.set(ctx=node_context)
+
+        return node_context
+
+    @mock_ec2
+    def test_delete_invalid_subnet_id(self):
+        ctx = self.get_mock_subnet_node_instance_context(
+            'test_delete_invalid_subnet_id')
+        ctx.instance.runtime_properties['aws_resource_id'] = 'subnet-0123abcd'
+        error = self.assertRaises(NonRecoverableError, delete_subnet, ctx=ctx)
+        self.assertIn(
+            'Cannot use_external_resource because resource '
+            'subnet-0123abcd is not in this account',
+            error.message)
+
+    @mock_ec2
+    @mock.patch('core.base.AwsBase.get_target_ids_of_relationship_type',
+                return_value=[Vpc(), Vpc()])
+    def test_create(self, *_):
+        ctx = self.get_mock_subnet_node_instance_context('test_create')
+        error = self.assertRaises(NonRecoverableError, create_subnet,
+                                  args=None, ctx=ctx)
+        self.assertIn('subnet can only be connected to one vpc', error.message)
+
+
+class TestRouteTableModule(VpcTestCase):
+
+    class RouteTable(object):
+        def __init__(self):
+            self.id = 'rtb-0123abcd'
+
+    class Vpc(object):
+        def __init__(self):
+            self.id = 'vpc-0123abcd'
+            self.cidr_block = '10.0.0.0/24'
+
+    def get_routes(self):
+        route = {
+            'destination_cidr_block': '10.0.0.0/24'
+        }
+        return [route]
+
+    def get_mock_route_table_node_instance_context(self, test_name, vpc=None):
+
+        node_context = self.mock_node_context(
+            test_name,
+            self.get_mock_node_properties(),
+            self.create_route_table_in_vpc_relationship(vpc)
+        )
+
+        node_context.node.type = ROUTE_TABLE_TYPE
+        node_context.node.type_hierarchy = \
+            [node_context.node.type, 'cloudify.nodes.Root']
+
+        current_ctx.set(ctx=node_context)
+
+        return node_context
+
+    def create_route_table_in_vpc_relationship(self, vpc):
+        return {
+            'type': constants.ROUTE_TABLE_VPC_RELATIONSHIP,
+            'target': self.Vpc() if not vpc else vpc.id
+        }
+
+    @mock_ec2
+    def test_delete_route_table(self, *_):
+        client = self.create_client()
+        vpc = self.create_vpc(client)
+        route_table = self.create_route_table(client, vpc)
+        ctx = \
+            self.get_mock_route_table_node_instance_context(
+                'test_delete_route_table', vpc)
+        ctx.instance.runtime_properties[
+            constants.EXTERNAL_RESOURCE_ID] = route_table.id
+        client.create_route(route_table_id=route_table.id,
+                            destination_cidr_block='10.0.0.0/24')
+        ctx.instance.runtime_properties['routes'] = self.get_routes()
+        delete_route_table(ctx=ctx)
+        self.assertNotIn(ctx.instance.runtime_properties,
+                         constants.EXTERNAL_RESOURCE_ID)
+
+
+class TestDhcpModule(VpcTestCase):
+
+    def get_mock_dhcp_node_instance_context(self, test_name):
+
+        node_context = self.mock_node_context(
+            test_name,
+            self.get_mock_node_properties()
+        )
+
+        node_context.node.type = DHCP_OPTIONS_TYPE
+        node_context.node.type_hierarchy = \
+            [node_context.node.type, 'cloudify.nodes.Root']
+
+        current_ctx.set(ctx=node_context)
+
+        return node_context
+
+    @mock_ec2
+    def test_delete_dhcp_option_set(self, *_):
+        client = self.create_client()
+        args = dict(
+            domain_name='example.com',
+            domain_name_servers=['ns1.example.com', 'ns2.example.com']
+        )
+        dhcp_options = self.create_dhcp_options(client, args=args)
+        ctx = self.get_mock_dhcp_node_instance_context(
+            'test_delete_dhcp_option_set')
+        ctx.instance.runtime_properties[
+            constants.EXTERNAL_RESOURCE_ID] = dhcp_options.id
+        error = self.assertRaises(
+            NonRecoverableError, delete_dhcp_options, ctx=ctx)
+        self.assertIn('returned False', error.message)

--- a/vpc/tests/test_vpc_workflow.py
+++ b/vpc/tests/test_vpc_workflow.py
@@ -1,0 +1,337 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Built-in Imports
+import re
+import mock
+
+# Third-party Imports
+from moto import mock_ec2
+
+# Cloudify Imports
+from cloudify.workflows import local
+from vpc_testcase import VpcTestCase
+
+VPC_ID_FORMAT = '^vpc\-[0-9a-z]{8}$'
+SUBNET_ID_FORMAT = '^subnet\-[0-9a-z]{8}$'
+IG_FORMAT = '^igw\-[0-9a-z]{8}$'
+VPN_GATEWAY_FORMAT = '^vgw\-[0-9a-z]{8}$'
+ACL_FORMAT = '^acl\-[0-9a-z]{8}$'
+DHCP_FORMAT = '^dopt\-[0-9a-z]{8}$'
+CUSTOMER_GATEWAY_FORMAT = '^cgw\-[0-9a-z]{8}$'
+ROUTE_TABLE_FORMAT = '^rtb\-[0-9a-z]{8}$'
+
+VPC_TYPE = 'cloudify.aws.nodes.VPC'
+SUBNET_TYPE = 'cloudify.aws.nodes.Subnet'
+INTERNET_GATEWAY_TYPE = 'cloudify.aws.nodes.InternetGateway'
+VPN_GATEWAY_TYPE = 'cloudify.aws.nodes.VPNGateway'
+CUSTOMER_GATEWAY_TYPE = 'cloudify.aws.nodes.CustomerGateway'
+ACL_TYPE = 'cloudify.aws.nodes.ACL'
+DHCP_OPTIONS_TYPE = 'cloudify.aws.nodes.DHCPOptions'
+ROUTE_TABLE_TYPE = 'cloudify.aws.nodes.RouteTable'
+
+IGNORED_LOCAL_WORKFLOW_MODULES = (
+    'worker_installer.tasks',
+    'plugin_installer.tasks',
+    'cloudify_agent.operations',
+    'cloudify_agent.installer.operations',
+)
+
+
+class TestWorkflowClean(VpcTestCase):
+
+    def with_bad_id(self, blueprint, resources,
+                    bad_input_name, bad_input_value):
+        inputs = self.get_blueprint_inputs(resources)
+        inputs.update({bad_input_name: bad_input_value})
+        return local.init_env(
+            blueprint,
+            name=self._testMethodName,
+            inputs=inputs,
+            ignored_modules=IGNORED_LOCAL_WORKFLOW_MODULES)
+
+    def expect_fail_on_workflow(self, cfy_local, workflow_name, message):
+        if 'creation_validation' in workflow_name:
+            output = self.assertRaises(
+                RuntimeError, cfy_local.execute,
+                'execute_operation',
+                parameters={
+                    'operation': 'cloudify.interfaces.validation.creation'
+                }, task_retries=5)
+        else:
+            output = self.assertRaises(
+                RuntimeError, cfy_local.execute,
+                workflow_name, task_retries=5)
+        self.assertIn(message, output.message)
+
+    @mock_ec2()
+    @mock.patch('vpc.dhcp.delete_dhcp_options', return_value=True)
+    @mock.patch('vpc.dhcp.restore_dhcp_options')
+    def test_blueprint(self, *_):
+        """ Tests the install workflow using the built in
+            workflows.
+        """
+
+        client = self.create_client()
+        existing_resources = self.create_all_existing_resources(client)
+        self.perform_relationships_on_all_existing_resources(
+            client, existing_resources)
+
+        cfy_local = local.init_env(
+            self.get_blueprint_path(),
+            name=self._testMethodName,
+            inputs=self.get_blueprint_inputs(existing_resources),
+            ignored_modules=IGNORED_LOCAL_WORKFLOW_MODULES)
+
+        # execute install workflow
+        cfy_local.execute('install', task_retries=5)
+        instances = cfy_local.storage.get_node_instances()
+        current_resources = self.get_current_list_of_used_resources(client)
+        for key, value in current_resources.items():
+            if ACL_TYPE in key or ROUTE_TABLE_TYPE in key:
+                self.assertEquals(4, len(value))
+            else:
+                self.assertEquals(2, len(value))
+
+        for instance in instances:
+            node = cfy_local.storage.get_node(instance.node_id)
+            if node.type in VPC_TYPE:
+                self.assertIsNotNone(
+                    re.match(
+                        VPC_ID_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+                self.assertIn(
+                    node.properties['cidr_block'],
+                    [
+                        resource.cidr_block
+                        for resource in current_resources[node.type]
+                        ]
+                )
+                self.assertIn(
+                    'default',
+                    [
+                        resource.instance_tenancy
+                        for resource in current_resources[VPC_TYPE]
+                        ]
+                )
+            if node.type in SUBNET_TYPE:
+                self.assertIsNotNone(
+                    re.match(
+                        SUBNET_ID_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+                self.assertIsNotNone(
+                    re.match(
+                        SUBNET_ID_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+            if node.type in INTERNET_GATEWAY_TYPE:
+                self.assertIsNotNone(
+                    re.match(
+                        IG_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+            if node.type in VPN_GATEWAY_TYPE:
+                self.assertIsNotNone(
+                    re.match(
+                        VPN_GATEWAY_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+            if node.type in ACL_FORMAT:
+                self.assertIsNotNone(
+                    re.match(
+                        ACL_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+            if node.type in DHCP_OPTIONS_TYPE:
+                self.assertIsNotNone(
+                    re.match(DHCP_FORMAT,
+                             instance.runtime_properties['aws_resource_id']
+                             )
+                )
+            if node.type in CUSTOMER_GATEWAY_TYPE:
+                self.assertIsNotNone(
+                    re.match(
+                        CUSTOMER_GATEWAY_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+            if node.type in ROUTE_TABLE_TYPE:
+                self.assertIsNotNone(
+                    re.match(
+                        ROUTE_TABLE_FORMAT,
+                        instance.runtime_properties['aws_resource_id']
+                    )
+                )
+                self.assertIn(
+                    'association_id',
+                    instance.runtime_properties
+                )
+                self.assertIn(
+                    'subnet_id',
+                    instance.runtime_properties
+                )
+
+        cfy_local.execute('uninstall', task_retries=5)
+        current_resources = self.get_current_list_of_used_resources(client)
+        for key, value in current_resources.items():
+            if ACL_TYPE in key:
+                self.assertEquals(3, len(value))
+            elif ROUTE_TABLE_TYPE in key:
+                self.assertEquals(2, len(value))
+            else:
+                self.assertEquals(1, len(value))
+
+        instances = cfy_local.storage.get_node_instances()
+        for instance in instances:
+            self.assertNotIn(instance.runtime_properties, 'aws_resource_id')
+
+    @mock_ec2()
+    def test_bad_external_blueprint(self):
+        """ Tests the install workflow using the built in
+            workflows.
+        """
+
+        client = self.create_client()
+        existing_resources = self.create_all_existing_resources(client)
+        self.perform_relationships_on_all_existing_resources(
+            client, existing_resources)
+        error_message = 'Cannot use_external_resource because resource'
+
+        for key, external_resource in existing_resources.items():
+            if re.match(VPC_ID_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_vpc_id', 'vpc-abcd1234')
+                self.expect_fail_on_workflow(
+                    cfy_local, 'install', error_message)
+            elif re.match(IG_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_internet_gateway_id', 'igw-abcd1234')
+                self.expect_fail_on_workflow(
+                    cfy_local, 'install', error_message)
+            elif re.match(ACL_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_network_acl_id', 'acl-0123abcd')
+                self.expect_fail_on_workflow(
+                    cfy_local, 'install', error_message)
+
+    @mock_ec2()
+    def test_blueprint_bootstrap(self):
+        """ Tests the install workflow using the built in
+            workflows.
+        """
+        client = self.create_client()
+        existing_resources = self.create_all_existing_resources(client)
+        self.perform_relationships_on_all_existing_resources(
+            client, existing_resources)
+
+        cfy_local = local.init_env(
+            self.get_blueprint_path(),
+            name=self._testMethodName,
+            inputs=self.get_blueprint_inputs(existing_resources),
+            ignored_modules=IGNORED_LOCAL_WORKFLOW_MODULES)
+
+        # execute creation validation
+        cfy_local.execute(
+            'execute_operation',
+            parameters={
+                'operation': 'cloudify.interfaces.validation.creation'
+            },
+            task_retries=5)
+
+    @mock_ec2()
+    def test_blueprint_bootstrap_bad_external_id(self):
+        """ Tests the install workflow using the built in
+            workflows.
+        """
+
+        client = self.create_client()
+        existing_resources = self.create_all_existing_resources(client)
+        self.perform_relationships_on_all_existing_resources(
+            client, existing_resources)
+        for key, external_resource in existing_resources.items():
+            if re.match(VPC_ID_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_vpc_id', 'vpc-abcd1234')
+                self.expect_fail_on_workflow(
+                    cfy_local,
+                    'creation_validation',
+                    'but the supplied vpc does not exist'
+                )
+            elif re.match(SUBNET_ID_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_subnet_id', 'subnet-abcd1234')
+                self.expect_fail_on_workflow(
+                    cfy_local,
+                    'creation_validation',
+                    'but the supplied subnet does not exist'
+                )
+            elif re.match(CUSTOMER_GATEWAY_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_customer_gateway_id', 'cgw-abcd1234')
+                self.expect_fail_on_workflow(
+                    cfy_local,
+                    'creation_validation',
+                    'but the supplied customer_gateway does not exist'
+                )
+            elif re.match(IG_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_internet_gateway_id', 'igw-abcd1234')
+                self.expect_fail_on_workflow(
+                    cfy_local,
+                    'creation_validation',
+                    'but the supplied internet_gateway does not exist'
+                )
+            elif re.match(ACL_FORMAT, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_network_acl_id', 'acl-0123abcd')
+                self.expect_fail_on_workflow(
+                    cfy_local,
+                    'creation_validation',
+                    'but the supplied network_acl does not exist'
+                )
+            elif re.match(DHCP_OPTIONS_TYPE, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_network_acl_id', 'acl-0123abcd')
+                self.expect_fail_on_workflow(
+                    cfy_local,
+                    'creation_validation',
+                    'but the supplied network_acl does not exist'
+                )
+            elif re.match(ROUTE_TABLE_TYPE, external_resource.id):
+                cfy_local = self.with_bad_id(
+                    self.get_blueprint_path(), existing_resources,
+                    'existing_route_table_id', 'rtb-0123abcd')
+                self.expect_fail_on_workflow(
+                    cfy_local,
+                    'creation_validation',
+                    'but the supplied route_table does not exist'
+                )

--- a/vpc/tests/vpc_testcase.py
+++ b/vpc/tests/vpc_testcase.py
@@ -1,0 +1,341 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Built-in Imports
+import os
+import testtools
+
+# Third-party Imports
+from boto.vpc import VPCConnection
+from vpc import constants
+from cloudify.mocks import MockCloudifyContext
+
+VPC_TYPE = 'cloudify.aws.nodes.VPC'
+SUBNET_TYPE = 'cloudify.aws.nodes.Subnet'
+INTERNET_GATEWAY_TYPE = 'cloudify.aws.nodes.InternetGateway'
+VPN_GATEWAY_TYPE = 'cloudify.aws.nodes.VPNGateway'
+CUSTOMER_GATEWAY_TYPE = 'cloudify.aws.nodes.CustomerGateway'
+ACL_TYPE = 'cloudify.aws.nodes.ACL'
+DHCP_OPTIONS_TYPE = 'cloudify.aws.nodes.DHCPOptions'
+ROUTE_TABLE_TYPE = 'cloudify.aws.nodes.RouteTable'
+
+IGNORED_LOCAL_WORKFLOW_MODULES = (
+    'worker_installer.tasks',
+    'plugin_installer.tasks',
+    'cloudify_agent.operations',
+    'cloudify_agent.installer.operations',
+)
+
+
+class VpcTestCase(testtools.TestCase):
+
+    def setUp(self):
+        super(VpcTestCase, self).setUp()
+
+    def tearDown(self):
+        super(VpcTestCase, self).tearDown()
+
+    def get_blueprint_path(self):
+
+        if 'vpc' not in os.getcwd():
+            blueprint_path = os.path.join(
+                'vpc/tests/blueprint', 'blueprint.yaml')
+        else:
+            blueprint_path = os.path.join('blueprint', 'blueprint.yaml')
+
+        return blueprint_path
+
+    def get_blueprint_inputs(self, resources):
+
+        inputs = {
+            'existing_vpc_id':
+                resources[VPC_TYPE].id,
+            'existing_subnet_id':
+                resources[SUBNET_TYPE].id,
+            'existing_internet_gateway_id':
+                resources[INTERNET_GATEWAY_TYPE].id,
+            'existing_vpn_gateway_id':
+                resources[VPN_GATEWAY_TYPE].id,
+            'existing_network_acl_id':
+                resources[ACL_TYPE].id,
+            'existing_dhcp_options_id':
+                resources[DHCP_OPTIONS_TYPE].id,
+            'existing_customer_gateway_id':
+                resources[CUSTOMER_GATEWAY_TYPE].id,
+            'existing_route_table_id':
+                resources[ROUTE_TABLE_TYPE].id
+        }
+        return inputs
+
+    def create_client(self):
+        return VPCConnection()
+
+    def create_vpc(self, vpc_client, args=None):
+        args = dict(cidr_block='11.0.0.0/24') if not args else args
+        vpc = vpc_client.create_vpc(**args)
+        return vpc
+
+    def create_subnet(self, vpc_client, vpc, args=None):
+        actual_args = dict(vpc_id=vpc.id, cidr_block='11.0.0.0/25')
+        if args:
+            actual_args.update(args)
+        subnet = vpc_client.create_subnet(**actual_args)
+        return subnet
+
+    def create_internet_gateway(self, vpc_client):
+        internet_gateway = vpc_client.create_internet_gateway()
+        return internet_gateway
+
+    def create_vpn_gateway(self, vpc_client, args=None):
+        args = dict(type='ipsec.1') if not args else args
+        vpn_gateway = vpc_client.create_vpn_gateway(**args)
+        return vpn_gateway
+
+    def create_network_acl(self, vpc_client, vpc, args=None):
+        actual_args = dict(vpc_id=vpc.id)
+        if args:
+            actual_args.update(args)
+        network_acl = vpc_client.create_network_acl(**actual_args)
+        return network_acl
+
+    def create_dhcp_options(self, vpc_client, args=None):
+        if not args:
+            args = dict(
+                netbios_name_servers=['biosserver-b.com', 'biosserver-a.com'],
+                netbios_node_type=2
+            )
+        dhcp_options = vpc_client.create_dhcp_options(**args)
+        return dhcp_options
+
+    def create_customer_gateway(self, vpc_client, args=None):
+        args = dict(
+            type='ipsec.1', ip_address='11.0.0.7', bgp_asn=65000
+        ) if not args else args
+        customer_gateway = vpc_client.create_customer_gateway(**args)
+        return customer_gateway
+
+    def create_route_table(self, vpc_client, existing_vpc):
+        args = dict(vpc_id=existing_vpc.id)
+        return vpc_client.create_route_table(**args)
+
+    def gateway_connected_to_vpc(self, vpc_client, source, target):
+
+        if source.get(INTERNET_GATEWAY_TYPE):
+            return vpc_client.attach_internet_gateway(
+                source.get(INTERNET_GATEWAY_TYPE).id, target.id)
+        elif source.get(VPN_GATEWAY_TYPE):
+            return vpc_client.attach_vpn_gateway(
+                source.get(VPN_GATEWAY_TYPE).id, target.id)
+
+    def customer_gateway_connected_to_vpn_gateway(self,
+                                                  vpc_client,
+                                                  source,
+                                                  target):
+        return vpc_client.create_vpn_connection(
+            'ipsec.1', source.id, target.id)
+
+    def network_acl_associated_with_subnet(self, vpc_client, source, target):
+        return vpc_client.associate_network_acl(source.id, target.id)
+
+    def dhcp_options_associated_with_vpc(self, vpc_client, source, target):
+        return vpc_client.associate_dhcp_options(source.id, target.id)
+
+    def route_table_associated_with_subnet(self, vpc_client, source, target):
+        return vpc_client.associate_route_table(source.id, target.id)
+
+    def route_to_gateway(self, vpc_client, source, target):
+        actual_args = dict(
+            route_table_id=source.id,
+            destination_cidr_block='0.0.0.0/0',
+            gateway_id=target.id
+        )
+        return vpc_client.create_route(**actual_args)
+
+    def perform_relationships_on_all_existing_resources(self,
+                                                        vpc_client,
+                                                        existing):
+
+        relationships = [
+            self.gateway_connected_to_vpc(
+                vpc_client,
+                {
+                    INTERNET_GATEWAY_TYPE: existing[INTERNET_GATEWAY_TYPE]
+                },
+                existing[VPC_TYPE]),
+            self.gateway_connected_to_vpc(
+                vpc_client,
+                {
+                    VPN_GATEWAY_TYPE: existing[VPN_GATEWAY_TYPE]
+                },
+                existing[VPC_TYPE]),
+            self.customer_gateway_connected_to_vpn_gateway(
+                vpc_client,
+                existing[CUSTOMER_GATEWAY_TYPE],
+                existing[VPN_GATEWAY_TYPE]),
+            self.network_acl_associated_with_subnet(
+                vpc_client,
+                existing[ACL_TYPE],
+                existing[SUBNET_TYPE]),
+            self.dhcp_options_associated_with_vpc(
+                vpc_client,
+                existing[DHCP_OPTIONS_TYPE],
+                existing[VPC_TYPE]),
+            self.route_table_associated_with_subnet(
+                vpc_client,
+                existing[ROUTE_TABLE_TYPE],
+                existing[SUBNET_TYPE]),
+            self.route_to_gateway(
+                vpc_client,
+                existing[ROUTE_TABLE_TYPE],
+                existing[INTERNET_GATEWAY_TYPE]
+            )
+        ]
+
+        return relationships
+
+    def create_all_existing_resources(self, vpc_client):
+
+        existing_vpc = self.create_vpc(vpc_client)
+        existing_subnet = self.create_subnet(vpc_client, existing_vpc)
+        existing_internet_gateway = self.create_internet_gateway(vpc_client)
+        existing_vpn_gateway = self.create_vpn_gateway(vpc_client)
+        existing_acl = self.create_network_acl(vpc_client, existing_vpc)
+        existing_dhcp_options = self.create_dhcp_options(vpc_client)
+        existing_customer_gateway = self.create_customer_gateway(vpc_client)
+        existing_route_table = \
+            self.create_route_table(vpc_client, existing_vpc)
+
+        resources = {
+            VPC_TYPE: existing_vpc,
+            SUBNET_TYPE: existing_subnet,
+            INTERNET_GATEWAY_TYPE: existing_internet_gateway,
+            VPN_GATEWAY_TYPE: existing_vpn_gateway,
+            ACL_TYPE: existing_acl,
+            DHCP_OPTIONS_TYPE: existing_dhcp_options,
+            CUSTOMER_GATEWAY_TYPE: existing_customer_gateway,
+            ROUTE_TABLE_TYPE: existing_route_table
+        }
+
+        return resources
+
+    def get_current_list_of_used_resources(self, vpc_client):
+
+        resources = {
+            VPC_TYPE: vpc_client.get_all_vpcs(),
+            SUBNET_TYPE: vpc_client.get_all_subnets(),
+            INTERNET_GATEWAY_TYPE: vpc_client.get_all_internet_gateways(),
+            VPN_GATEWAY_TYPE: vpc_client.get_all_vpn_gateways(),
+            ACL_TYPE: vpc_client.get_all_network_acls(),
+            DHCP_OPTIONS_TYPE: vpc_client.get_all_dhcp_options(),
+            CUSTOMER_GATEWAY_TYPE: vpc_client.get_all_customer_gateways(),
+            ROUTE_TABLE_TYPE: vpc_client.get_all_route_tables()
+        }
+
+        return resources
+
+    def mock_node_context(self, test_name,
+                          node_properties=None, relationships=None):
+
+        ctx = MockCloudifyContext(
+            node_id=test_name,
+            properties=node_properties
+        )
+
+        ctx.instance.relationships = [] if not relationships else relationships
+
+        return ctx
+
+    def get_mock_node_properties(self, node_template_properties=None):
+
+        test_properties = {
+            constants.AWS_CONFIG_PROPERTY: {},
+            'use_external_resource': False,
+            'resource_id': 'test_security_group',
+        }
+
+        if node_template_properties:
+            test_properties.update(node_template_properties)
+
+        return test_properties
+
+    def vpc_node_template_properties(self, inputs):
+
+        return {
+            'cidr_block':
+                inputs.get('cidr_block')
+                if 'cidr_block' in inputs.keys() else '10.0.0.0/24',
+            'instance_tenancy':
+                inputs.get('instance_tenancy')
+                if 'instance_tenancy' in inputs.keys() else 'default',
+            'enable_vpc_classic_link':
+                inputs.get('enable_vpc_classic_link')
+                if 'enable_vpc_classic_link' in inputs.keys() else False
+        }
+
+    def subnet_node_template_properties(self, inputs):
+
+        return {
+            'cidr_block':
+                inputs.get('cidr_block')
+                if 'cidr_block' in inputs.keys() else '10.0.0.0/25',
+            'availability_zone':
+                inputs.get('availability_zone')
+                if 'availability_zone' in inputs.keys() else ''
+        }
+
+    def network_acl_node_template_properties(self, inputs):
+
+        return {
+            'acl_network_entries':
+                [entry for entry in inputs.get('entries')]
+                if 'entries' in inputs.keys() else []
+        }
+
+    def vpn_gateway_node_template_properties(self, inputs):
+
+        return {
+            'type': 'ipsec.1',
+            'availability_zone':
+                inputs.get('availability_zone')
+                if 'availability_zone' in inputs.keys() else ''
+        }
+
+    def customer_gateway_node_template_properties(self, inputs):
+
+        return {
+            'type': 'ipsec.1',
+            'ip_address':
+                inputs.get('ip_address')
+                if 'ip_address' in inputs.keys() else '10.0.0.7',
+            'bgp_asn': '35000'
+        }
+
+    def dhcp_options_node_template_properties(self, inputs):
+
+        return {
+            'domain_name':
+                inputs.get('domain_name')
+                if 'domain_name' in inputs.keys() else 'example.com',
+            'domain_name_servers':
+                [dns for dns in inputs.get('domain_name_servers')]
+                if 'domain_name_servers' in inputs.keys() else [],
+            'ntp_servers':
+                [ntp for ntp in inputs.get('ntp_servers')]
+                if 'ntp_servers' in inputs.keys() else [],
+            'netbios_name_servers':
+                [nbns for nbns in inputs.get('netbios_name_servers')]
+                if 'netbios_name_servers' in inputs.keys() else [],
+            'netbios_node_type': 2
+        }

--- a/vpc/vpc.py
+++ b/vpc/vpc.py
@@ -1,0 +1,279 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Third-party Imports
+from boto import exception
+
+# Cloudify imports
+from . import constants
+from . import connection
+from core.base import AwsBaseNode, AwsBaseRelationship, RouteMixin
+from cloudify import ctx
+from cloudify.decorators import operation
+from cloudify.exceptions import NonRecoverableError, RecoverableError
+
+
+@operation
+def creation_validation(**_):
+    return Vpc().creation_validation()
+
+
+@operation
+def create_vpc(**_):
+    return Vpc().created()
+
+
+@operation
+def delete(**_):
+    return Vpc().deleted()
+
+
+@operation
+def create_vpc_peering_connection(target_account_id, routes, **_):
+    return VpcPeeringConnection(target_account_id, routes).associated()
+
+
+@operation
+def delete_vpc_peering_connection(**_):
+    return VpcPeeringConnection().disassociated()
+
+
+@operation
+def accept_vpc_peering_connection(**_):
+    target_aws_config = ctx.target.node.properties['aws_config']
+    client = \
+        connection.VPCConnectionClient().client(aws_config=target_aws_config)
+    return VpcPeeringConnection(client=client).accept_vpc_peering_connection()
+
+
+class VpcPeeringConnection(AwsBaseRelationship, RouteMixin):
+
+    def __init__(self, target_account_id=None, routes=None, client=None):
+        super(VpcPeeringConnection, self).__init__(client=client)
+        self.not_found_error = 'InvalidVpcPeeringConnectionId.NotFound'
+        self.resource_id = None
+        self.target_account_id = target_account_id
+        self.routes = routes
+        self.source_vpc_id = \
+            ctx.source.instance.runtime_properties.get('vpc_id')
+        self.target_vpc_id = \
+            ctx.target.instance.runtime_properties.get(
+                constants.EXTERNAL_RESOURCE_ID
+            )
+        self.source_route_table_id =\
+            ctx.source.instance.runtime_properties.get(
+                constants.EXTERNAL_RESOURCE_ID
+            )
+        self.source_vpc_peering_connection_id = \
+            self.get_vpc_peering_connection_id(
+                ctx.source.instance,
+                self.source_vpc_id,
+                'vpc_id')
+        self.target_vpc_peering_connection_id = \
+            self.get_vpc_peering_connection_id(
+                ctx.target.instance,
+                self.target_vpc_id,
+                'vpc_peer_id')
+        self.source_get_all_handler = {
+            'function': self.client.get_all_route_tables,
+            'argument':
+            '{0}_ids'.format(constants.ROUTE_TABLE['AWS_RESOURCE_TYPE'])
+        }
+
+    def associated(self):
+        if self.use_source_external_resource_naively():
+            ctx.logger.info(
+                'executing vpc peering connection association '
+                'despite the fact that this is an external relationship'
+            )
+        if self.associate():
+            return self.post_associate()
+
+        raise NonRecoverableError(
+            'Unable to associate {0} with {1}.'
+            .format(self.source_resource_id, self.target_resource_id))
+
+    def associate(self):
+
+        associate_args = self._generate_association_args()
+        vpc_peering_connection = \
+            self.execute(self.client.create_vpc_peering_connection,
+                         associate_args, raise_on_falsy=True)
+        self.resource_id = vpc_peering_connection.id
+
+        for route in self.routes:
+            route.update(
+                route_table_id=self.source_route_table_id,
+                vpc_peering_connection_id=self.resource_id
+            )
+            self.create_route(self.source_route_table_id, route,
+                              route_table_ctx_instance=ctx.source.instance)
+
+        return True
+
+    def _generate_association_args(self):
+        return dict(
+            vpc_id=self.source_vpc_id,
+            peer_vpc_id=self.target_vpc_id,
+            peer_owner_id=self.target_account_id
+        )
+
+    def disassociate(self):
+        self.delete_routes()
+        disassociate_args = dict(
+            vpc_peering_connection_id=self.source_vpc_peering_connection_id
+        )
+        return self.execute(self.client.delete_vpc_peering_connection,
+                            disassociate_args, raise_on_falsy=True)
+
+    def post_associate(self):
+        cx = dict(
+            vpc_peering_connection_id=self.resource_id,
+            vpc_id=self.source_vpc_id,
+            vpc_peer_id=self.target_vpc_id,
+            routes=self.routes
+        )
+        if 'vpc_peering_connections' \
+                not in ctx.source.instance.runtime_properties:
+            ctx.source.instance.runtime_properties[
+                'vpc_peering_connections'] = []
+        ctx.source.instance.runtime_properties[
+            'vpc_peering_connections'].append(cx)
+        if 'vpc_peering_connections' \
+                not in ctx.target.instance.runtime_properties:
+            ctx.target.instance.runtime_properties[
+                'vpc_peering_connections'] = []
+        ctx.target.instance.runtime_properties[
+            'vpc_peering_connections'].append(cx)
+        return True
+
+    def delete_routes(self):
+        vpc_peering_connections = \
+            ctx.source.instance.runtime_properties \
+            .get('vpc_peering_connections')
+        for vpc_peering_connection in vpc_peering_connections:
+            ctx.logger.info('{0}'.format(vpc_peering_connection))
+            for route in vpc_peering_connection['routes']:
+                self.delete_route(
+                    self.source_route_table_id, route,
+                    route_table_ctx_instance=ctx.source.instance)
+
+    def get_vpc_peering_connection_id(self, ctx_instance,
+                                      vpc_id, property_name):
+
+        vpc_peering_connections = \
+            ctx_instance.runtime_properties \
+            .get('vpc_peering_connections')
+
+        if not vpc_peering_connections:
+            return None
+
+        for vpc_peering_connection in vpc_peering_connections:
+            if vpc_id in vpc_peering_connection[property_name]:
+                return vpc_peering_connection['vpc_peering_connection_id']
+
+        return None
+
+    def accept_vpc_peering_connection(self):
+
+        try:
+            output = self.client.accept_vpc_peering_connection(
+                self.target_vpc_peering_connection_id)
+        except exception.EC2ResponseError as e:
+            if self.not_found_error in str(e):
+                raise NonRecoverableError('{0}'.format(str(e)))
+            elif '<Code>VpcPeeringConnectionAlreadyExists</Code>' in str(e):
+                return True
+            raise RecoverableError('{0}'.format(str(e)))
+
+        if output:
+            if not self.add_route_to_target_vpc():
+                raise NonRecoverableError(
+                    'Unable to save route to target VPC route table.')
+
+        return output
+
+    def add_route_to_target_vpc(self):
+
+        source_vpc_cidr_block = ''
+        target_route_table_id = ''
+
+        vpcs = self.execute(self.client.get_all_vpcs)
+        for vpc in vpcs:
+            if vpc.id == self.source_vpc_id:
+                source_vpc_cidr_block = vpc.cidr_block
+
+        new_route = dict(
+            destination_cidr_block=source_vpc_cidr_block,
+            vpc_peering_connection_id=self.source_vpc_peering_connection_id
+        )
+
+        route_tables = self.execute(self.client.get_all_route_tables)
+        for route_table in route_tables:
+            if route_table.vpc_id == self.target_vpc_id:
+                target_route_table_id = route_table.id
+
+        return self.create_route(
+            route_table_id=target_route_table_id,
+            route=new_route
+        )
+
+
+class Vpc(AwsBaseNode):
+
+    def __init__(self):
+        super(Vpc, self).__init__(
+            constants.VPC['AWS_RESOURCE_TYPE'],
+            constants.VPC['REQUIRED_PROPERTIES']
+        )
+        self.not_found_error = constants.VPC['NOT_FOUND_ERROR']
+        self.get_all_handler = {
+            'function': self.client.get_all_vpcs,
+            'argument': '{0}_ids'.format(constants.VPC['AWS_RESOURCE_TYPE'])
+        }
+
+    def use_external_resource_naively(self):
+
+        if not self.is_external_resource:
+            return False
+
+        resource = self.get_resource()
+
+        if not resource:
+            self.raise_forbidden_external_resource(self.resource_id)
+
+        ctx.instance.runtime_properties['default_dhcp_options_id'] = \
+            resource.dhcp_options_id
+
+        return True
+
+    def create(self):
+
+        create_args = dict(
+            cidr_block=ctx.node.properties['cidr_block'],
+            instance_tenancy=ctx.node.properties['instance_tenancy']
+        )
+
+        vpc = self.execute(self.client.create_vpc,
+                           create_args, raise_on_falsy=True)
+        self.resource_id = vpc.id
+        ctx.instance.runtime_properties['default_dhcp_options_id'] = \
+            vpc.dhcp_options_id
+
+        return True
+
+    def delete(self):
+        vpc = self.get_resource()
+        return self.execute(vpc.delete, raise_on_falsy=True)


### PR DESCRIPTION
- Redesign Underlying Common Elements
- Add plugin.yaml/types
- Add create/delete vpc
- Add create/delete snapshots
- Add create/delete subnets
- Add create/delete/attach/detach gateways
- Add Unit Tests
- Updated ElasticIP to Support VPC
- Created Public version of private method for use by vpc package
- Updated boto dependency version
- Add routes
- Add ACL
- Slight Refactoring of Tests
- Add a Demo Folder (Temporary)
- Fixed Flake8
- Add Unit tests to reach over 90 percent coverage
- Added Route Table Associated with Subnet Rel
- Removed ClassicLinkEnabled
- Added 3.3 Manager Blueprint