### PR TITLE
Added owner='self'

### DIFF
--- a/system_tests/ec2_handler.py
+++ b/system_tests/ec2_handler.py
@@ -352,7 +352,7 @@ class EC2Handler(BaseHandler):
 
     def _snapshots(self, ec2_client):
         return [(ss.id, ss.id)
-                for ss in ec2_client.get_all_snapshots()]
+                for ss in ec2_client.get_all_snapshots(owner='self')]
 
     def _elbs(self, elb_client):
         return [(elb.name, elb.name)


### PR DESCRIPTION
get_all_snapshots needs this argument to prevent from getting snapshot ids that are not in the account