### PR TITLE
Add Default to Target Account ID

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -821,6 +821,7 @@ relationships:
             target_account_id:
               description: >
                 The 12 digit account ID that the target VPC belongs to.
+              default: ''
             routes:
               description: >
                 A list of cloudify.datatypes.aws.Route for assignment to the source Route Table.

--- a/system_tests/manager/resources/vpc_test_blueprint.yaml
+++ b/system_tests/manager/resources/vpc_test_blueprint.yaml
@@ -287,7 +287,6 @@ node_templates:
             preconfigure:
               implementation: aws.vpc.vpc.create_vpc_peering_connection
               inputs:
-                target_account_id: '535075449278'
                 routes:
                     - destination_cidr_block: { get_property: [ vpc_two, cidr_block ] }
       - type: cloudify.relationships.depends_on

--- a/vpc/tests/blueprint/plugin.yaml
+++ b/vpc/tests/blueprint/plugin.yaml
@@ -821,6 +821,7 @@ relationships:
             target_account_id:
               description: >
                 The 12 digit account ID that the target VPC belongs to.
+              default: ''
             routes:
               description: >
                 A list of cloudify.datatypes.aws.Route for assignment to the source Route Table.


### PR DESCRIPTION
Default Account ID can be None - don't require.