### PR TITLE
Cfy 5161 deploy instance to manager subnet

### DIFF
--- a/ec2/constants.py
+++ b/ec2/constants.py
@@ -85,3 +85,10 @@ BOTO_CONFIG_SCHEMA = {
     'Credentials': ['aws_access_key_id', 'aws_secret_access_key'],
     'Boto': ['ec2_region_name', 'ec2_region_endpoint']
 }
+
+# Agents Base Values
+AGENTS_KEYPAIR = 'agents_keypair'
+AGENTS_SECURITY_GROUP = 'agents_security_group'
+AGENTS_SUBNET = 'agents_subnet'
+AGENTS_AWS_INSTANCE_PARAMETERS = 'agents_base_instance_parameters'
+AGENTS_VPC = 'agents_vpc'

--- a/ec2/instance.py
+++ b/ec2/instance.py
@@ -542,17 +542,18 @@ def _get_instance_parameters():
             constants.INSTANCE_SECURITY_GROUP_RELATIONSHIP,
             ctx.instance)
 
-    if provider_variables.get('agents_security_group'):
+    if provider_variables.get(constants.AGENTS_SECURITY_GROUP):
         attached_group_ids.append(
-            provider_variables['agents_security_group'])
+            provider_variables[constants.AGENTS_SECURITY_GROUP])
 
-    parameters = {
+    parameters = provider_variables.get(constants.AGENTS_AWS_INSTANCE_PARAMETERS)
+    parameters.update({
         'image_id': ctx.node.properties['image_id'],
         'instance_type': ctx.node.properties['instance_type'],
         'security_group_ids': attached_group_ids,
         'key_name': _get_instance_keypair(provider_variables),
         'subnet_id': _get_instance_subnet(provider_variables)
-    }
+    })
 
     parameters.update(ctx.node.properties['parameters'])
     parameters = _handle_userdata(parameters)
@@ -569,8 +570,8 @@ def _get_instance_keypair(provider_variables):
         utils.get_target_external_resource_ids(
             constants.INSTANCE_KEYPAIR_RELATIONSHIP, ctx.instance)
 
-    if not list_of_keypairs and provider_variables.get('agents_keypair'):
-        list_of_keypairs.append(provider_variables['agents_keypair'])
+    if not list_of_keypairs and provider_variables.get(constants.AGENTS_KEYPAIR):
+        list_of_keypairs.append(provider_variables[constants.AGENTS_KEYPAIR])
     elif len(list_of_keypairs) > 1:
         raise NonRecoverableError(
             'Only one keypair may be attached to an instance.')
@@ -599,8 +600,8 @@ def _get_instance_subnet(provider_variables):
             constants.INSTANCE_SUBNET_RELATIONSHIP, ctx.instance
         )
 
-    if not list_of_subnets and provider_variables.get('agents_subnet'):
-        list_of_subnets.append(provider_variables['agents_subnet'])
+    if not list_of_subnets and provider_variables.get(constants.AGENTS_SUBNET):
+        list_of_subnets.append(provider_variables[constants.AGENTS_SUBNET])
     elif len(list_of_subnets) > 1:
         raise NonRecoverableError(
             'instance may only be attached to one subnet')

--- a/ec2/utils.py
+++ b/ec2/utils.py
@@ -173,12 +173,12 @@ def get_provider_variables():
 
     provider_config = ctx.provider_context.get('resources', {})
 
-    agents_keypair = provider_config.get('agents_keypair', {})
-    agents_security_group = provider_config.get('agents_security_group', {})
-
     provider_context = {
-        "agents_keypair": agents_keypair.get('id'),
-        "agents_security_group": agents_security_group.get('id')
+        constants.AGENTS_KEYPAIR: provider_config.get(constants.AGENTS_KEYPAIR, {}).get('id'),
+        constants.AGENTS_SECURITY_GROUP: provider_config.get(constants.AGENTS_SECURITY_GROUP, {}).get('id'),
+        constants.AGENTS_SUBNET: provider_config.get(constants.AGENTS_SUBNET, {}).get('id'),
+        constants.AGENTS_VPC: provider_config.get(constants.AGENTS_VPC, {}).get('id'),
+        constants.AGENTS_AWS_INSTANCE_PARAMETERS: provider_config.get(constants.AGENTS_AWS_INSTANCE_PARAMETERS, {})
     }
 
     return provider_context

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,6 +5,7 @@
 plugins:
   aws:
     executor: central_deployment_agent
+    source: https://github.com/cloudify-cosmo/cloudify-aws-plugin/archive/1.4.zip
     package_name: cloudify-aws-plugin
     package_version: '1.4'
 

--- a/system_tests/manager/resources/relationships-blueprint.yaml
+++ b/system_tests/manager/resources/relationships-blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
-  - http://www.getcloudify.org/spec/aws-plugin/1.3.1/plugin.yaml
+  - http://www.getcloudify.org/spec/aws-plugin/1.4/plugin.yaml
 
 inputs:
 

--- a/system_tests/manager/resources/simple-blueprint.yaml
+++ b/system_tests/manager/resources/simple-blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
-  - http://www.getcloudify.org/spec/aws-plugin/1.3.1/plugin.yaml
+  - http://www.getcloudify.org/spec/aws-plugin/1.4/plugin.yaml
 
 inputs:
 

--- a/system_tests/manager/resources/user-data-agent-install-blueprint.yaml
+++ b/system_tests/manager/resources/user-data-agent-install-blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
-  - http://www.getcloudify.org/spec/aws-plugin/1.3.1/plugin.yaml
+  - http://www.getcloudify.org/spec/aws-plugin/1.4/plugin.yaml
 
 inputs:
 

--- a/system_tests/manager/resources/vpc_test_blueprint.yaml
+++ b/system_tests/manager/resources/vpc_test_blueprint.yaml
@@ -4,7 +4,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
-  - http://www.getcloudify.org/spec/aws-plugin/1.3.1/plugin.yaml
+  - http://www.getcloudify.org/spec/aws-plugin/1.4/plugin.yaml
 
 inputs:
 


### PR DESCRIPTION
We need to be able to (in order of appearance):
1) check if the manager offers a provider context (already exists)
2) inject base instance 
  - key (already exists)
  - security group (already exists)
  - subnet (already partially implemented)
  - misc parameters
3) override with properties/relationships provided values and user provided parameters
4) create instance (already exists)