### PR TITLE
Adding VPC resource create retry support

### DIFF
--- a/cloudify_aws/base.py
+++ b/cloudify_aws/base.py
@@ -302,18 +302,23 @@ class AwsBaseNode(AwsBase):
         return False
 
     def created(self, args=None):
-
+        '''Helper to create resources'''
         ctx.logger.info(
             'Attempting to create {0} {1}.'
             .format(self.aws_resource_type,
                     self.cloudify_node_instance_id))
-
-        if self.use_external_resource_naively() or self.create(args):
+        # Create the resource, if needed
+        ret = self.use_external_resource_naively() or self.create(args)
+        # The resource either already exists or was created successfully
+        if ret is True:
             return self.post_create()
-
-        raise NonRecoverableError(
-            'Neither external resource, nor Cloudify resource, '
-            'unable to create this resource.')
+        # The resource does not exist or was not created successfully
+        elif ret is False:
+            raise NonRecoverableError(
+                'Neither external resource, nor Cloudify resource, '
+                'unable to create this resource.')
+        # The override likely returned a retry operation to pass along
+        return ret
 
     def use_external_resource_naively(self):
 

--- a/cloudify_aws/vpc/subnet.py
+++ b/cloudify_aws/vpc/subnet.py
@@ -69,11 +69,19 @@ class Subnet(AwsBaseNode):
             # Get the resource object
             subnet = self.get_resource()
         # If the operation is still pending, set the ID and retry
-        if subnet.state == 'pending':
-            set_external_resource_id(self.resource_id, ctx.instance)
-            return ctx.operation.retry(
-                message='Waiting to verify that AWS resource {0} '
-                'has been added to your account.'.format(self.resource_id))
+        if hasattr(subnet, 'state'):
+            ctx.logger.debug('AWS resource {0} returned a state of "{1}"'
+                             .format(self.resource_id, subnet.state))
+            if subnet.state == 'pending':
+                set_external_resource_id(self.resource_id, ctx.instance)
+                return ctx.operation.retry(
+                    message='Waiting to verify that AWS resource {0} '
+                    'has been added to your account.'.format(self.resource_id))
+        else:
+            ctx.logger.warn('AWS resource {0} returned an '
+                            'unexpected response (missing state)'
+                            .format(self.resource_id))
+            return False
         return True
 
     def _generate_creation_args(self):

--- a/cloudify_aws/vpc/subnet.py
+++ b/cloudify_aws/vpc/subnet.py
@@ -16,6 +16,7 @@
 # Cloudify imports
 from cloudify_aws import constants, connection, utils
 from cloudify_aws.base import AwsBaseNode
+from cloudify_aws.utils import set_external_resource_id
 from cloudify import ctx
 from cloudify.decorators import operation
 from cloudify.exceptions import NonRecoverableError
@@ -55,13 +56,24 @@ class Subnet(AwsBaseNode):
             'argument': '{0}_ids'.format(constants.SUBNET['AWS_RESOURCE_TYPE'])
         }
 
-    def create(self, args):
-        create_args = utils.update_args(
-            self._generate_creation_args(),
-            args)
-        subnet = self.execute(self.client.create_subnet,
-                              create_args, raise_on_falsy=True)
-        self.resource_id = subnet.id
+    def create(self, args=None):
+        '''Override for resource create operation'''
+        if ctx.operation.retry_number == 0:
+            # Create the resource
+            create_args = utils.update_args(
+                self._generate_creation_args(), args)
+            subnet = self.execute(self.client.create_subnet,
+                                  create_args, raise_on_falsy=True)
+            self.resource_id = subnet.id
+        else:
+            # Get the resource object
+            subnet = self.get_resource()
+        # If the operation is still pending, set the ID and retry
+        if subnet.state == 'pending':
+            set_external_resource_id(self.resource_id, ctx.instance)
+            return ctx.operation.retry(
+                message='Waiting to verify that AWS resource {0} '
+                'has been added to your account.'.format(self.resource_id))
         return True
 
     def _generate_creation_args(self):

--- a/cloudify_aws/vpc/tests/test_vpc_unittests.py
+++ b/cloudify_aws/vpc/tests/test_vpc_unittests.py
@@ -129,6 +129,7 @@ class TestSubnetModule(VpcTestCase):
         return_value=[Vpc(), Vpc()])
     def test_create(self, *_):
         ctx = self.get_mock_subnet_node_instance_context('test_create')
+        ctx.operation._operation_context['retry_number'] = 0
         error = self.assertRaises(NonRecoverableError, subnet.create_subnet,
                                   args=None, ctx=ctx)
         self.assertIn('subnet can only be connected to one vpc', error.message)


### PR DESCRIPTION
I've been running into race condition issues when creating full network environments in AWS and it's because some resources are being put into a "pending" state after running the create operation and they're not fully available when the next operation attempts to use the resource.  I put in a hook for using the retry operation as well as implemented it in the Subnet create override. 