### PR TITLE
Make accept_vpc_peering_connection work

### DIFF
--- a/cloudify_aws/vpc/vpc.py
+++ b/cloudify_aws/vpc/vpc.py
@@ -218,7 +218,7 @@ class VpcPeeringConnection(AwsBaseRelationship, RouteMixin):
                 raise NonRecoverableError(
                     'Unable to save route to target VPC route tables.')
 
-        return output
+        return True
 
     def add_route_to_target_vpc(self):
         """ Adds a return route on to the target VPC route tables


### PR DESCRIPTION
Change the return on `accept_vpc_peering_connection` to make it so it doesn't throw the error:

```
'install' workflow execution failed: RuntimeError: Workflow failed: Task failed 'cloudify_aws.vpc.vpc.accept_vpc_peering_connection' -> Unhandled exception occurred in operatio
n dispatch: Traceback (most recent call last):
  File "/tmp/pip-build-JNE7J6/cloudify-plugins-common/cloudify/dispatch.py", line 690, in <module>
  File "/tmp/pip-build-JNE7J6/cloudify-plugins-common/cloudify/dispatch.py", line 686, in main
  File "/usr/lib64/python2.7/json/__init__.py", line 189, in dump
    for chunk in iterable:
  File "/usr/lib64/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/usr/lib64/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/usr/lib64/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: VpcPeeringConnection:pcx-9d95f9f4 is not JSON serializable
```