### PR TITLE
eks update_nodegroup_config

### DIFF
--- a/cloudify_aws/eks/resources/node_group.py
+++ b/cloudify_aws/eks/resources/node_group.py
@@ -91,13 +91,7 @@ class EKSNodeGroup(EKSBase):
         """
             Updates the AWS EKS Node Group.
         """
-        valid_keys = [
-            "clusterName", "nodegroupName", "labels", "taints",
-            "scalingConfig", "updateConfig", "clientRequestToken"
-        ]
-        valid_params = {x: params.get(x) for x in valid_keys
-                        if params.get(x) is not None}
-        return self.make_client_call('update_nodegroup_config', valid_params)
+        return self.make_client_call('update_nodegroup_config', params)
 
     def delete(self, params=None):
         """
@@ -166,8 +160,14 @@ def start(ctx, iface, resource_config, **_):
         )
     utils.update_resource_id(ctx.instance, resource_id)
     iface = prepare_describe_node_group_filter(resource_config.copy(), iface)
+    valid_keys = [
+        "clusterName", "nodegroupName", "labels", "taints",
+        "scalingConfig", "updateConfig", "clientRequestToken"
+    ]
+    valid_params = {x: params.get(x) for x in valid_keys
+                    if params.get(x) is not None}
     try:
-        response = iface.start(params)
+        response = iface.start(valid_params)
     except ClientError as e:
         raise OperationRetry(
             'Waiting for cluster to be ready...{e}'.format(e=e))

--- a/cloudify_aws/eks/resources/node_group.py
+++ b/cloudify_aws/eks/resources/node_group.py
@@ -175,7 +175,7 @@ def start(ctx, iface, resource_config, **_):
         resource_arn = response.get(NODEGROUP).get(NODEGROUP_ARN)
         utils.update_resource_arn(ctx.instance, resource_arn)
     # wait for nodegroup to be active
-    ctx.logger.info("Waiting for NodeGroup to become Active")
+    ctx.logger.info("Waiting for NodeGroup to become \"Active\".")
     iface.wait_for_nodegroup(params, 'nodegroup_active')
 
 

--- a/cloudify_aws/eks/tests/test_nodegroup.py
+++ b/cloudify_aws/eks/tests/test_nodegroup.py
@@ -125,6 +125,27 @@ class TestEKSNodeGroup(TestBase):
             self.node_group.create(params)[node_group.NODEGROUP],
             response.get(node_group.NODEGROUP))
 
+    def test_class_start(self):
+        params = {
+            node_group.CLUSTER_NAME: 'test_cluster_name',
+            node_group.NODEGROUP_NAME: 'test_node_group_name'
+        }
+        response = \
+            {
+                node_group.NODEGROUP: {
+                    'nodegroupArn': 'test_node_group_arn',
+                    'nodegroupName': 'test_node_group_name',
+                    'clusterName': 'test_cluster_name',
+                    'status': 'test_status',
+                },
+            }
+
+        self.node_group.client = self.make_client_function(
+            'update_nodegroup_config', return_value=response)
+
+        self.assertEqual(self.node_group.start(params), response)
+
+
     def test_class_delete(self):
         params = {
             node_group.CLUSTER_NAME: 'test_cluster_name',
@@ -171,6 +192,35 @@ class TestEKSNodeGroup(TestBase):
 
         iface.create = self.mock_return(response)
         node_group.create(ctx, iface, config)
+        self.assertEqual(
+            ctx.instance.runtime_properties[constants.EXTERNAL_RESOURCE_ID],
+            'test_node_group_name'
+        )
+
+    def test_start(self):
+        ctx = self.get_mock_ctx("NodeGroup")
+        valid_config = {
+            node_group.CLUSTER_NAME: 'test_cluster_name',
+            node_group.NODEGROUP_NAME: 'test_node_group_name',
+            "scalingConfig": {
+               "maxSize": 2
+            }
+        }
+        extended_config = {"diskSize": 20, **valid_config}
+        iface = MagicMock()
+        response = \
+            {
+                node_group.NODEGROUP: {
+                    'nodegroupArn': 'test_node_group_arn',
+                    'nodegroupName': 'test_node_group_name',
+                    'clusterName': 'test_cluster_name',
+                    'status': 'test_status',
+                },
+            }
+
+        iface.start = self.mock_return(response)
+        node_group.start(ctx, iface, extended_config)
+        iface.start.assert_called_with(valid_config)
         self.assertEqual(
             ctx.instance.runtime_properties[constants.EXTERNAL_RESOURCE_ID],
             'test_node_group_name'

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3516,6 +3516,9 @@ node_types:
         create:
           implementation: aws.cloudify_aws.eks.resources.node_group.prepare
           inputs: *operation_inputs
+        start:
+          implementation: aws.cloudify_aws.eks.resources.node_group.start
+          inputs: *operation_inputs
         configure:
           implementation: aws.cloudify_aws.eks.resources.node_group.create
           inputs: *operation_inputs


### PR DESCRIPTION
Adding [update_nodegroup_config](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/eks.html#EKS.Client.update_nodegroup_config) as `cloudify.interfaces.lifecycle.start`.